### PR TITLE
Suggested fixes for issues #64 and #67

### DIFF
--- a/bayespy/inference/vmp/vmp.py
+++ b/bayespy/inference/vmp/vmp.py
@@ -144,6 +144,11 @@ class VB():
         else:
             plot_nodes = [self[x] for x in plot]
 
+        # Make certain that at least one of the nodes in the update list
+        # has been observed
+        if ~np.any([n.observed for n in nodes]):
+            raise Exception("At least one node in the update set must be observed.")
+
         converged = False
 
         for i in range(repeat):

--- a/bayespy/plot.py
+++ b/bayespy/plot.py
@@ -512,7 +512,7 @@ def gaussian_mixture_2d(X, alpha=None, scale=2, fill=False, axes=None, **kwargs)
     return
     
     
-def _hinton(W, error=None, vmax=None, square=True, axes=None):
+def _hinton(W, error=None, vmax=None, square=False, axes=None):
     """
     Draws a Hinton diagram for visualizing a weight matrix. 
 
@@ -538,7 +538,8 @@ def _hinton(W, error=None, vmax=None, square=True, axes=None):
     axes.fill(0.5+np.array([0,width,width,0]),
               0.5+np.array([0,0,height,height]),
               'gray')
-    axes.axis('off')
+    axes.axis('on')
+    axes.axis('image')
     if square:
         axes.axis('equal')
     axes.invert_yaxis()


### PR DESCRIPTION
Note, this does set the default of having a square hinton diagram equal to False, but since we're bounding to the data size, I think that's okay.  Since the axes are now left in their default state, if someone wants to disable the x-ticks and y-ticks, they can do so by grabbing the current axis and turning off the ticks, e.g., 

```python
bplt.pyplot.xticks([])
bplt.pyplot.yticks([])
```