### PR TITLE
Add the change log to the release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README*
 include INSTALL*
 include LICENSE
+include CHANGELOG*
 
 # Include header files
 recursive-include bayespy *.h


### PR DESCRIPTION
As recommended by Debian and other Linux distributions. Also helps package maintainers with their review of the changes introduced by a new release, without having to inspect the whole diff of the source tree.