### PR TITLE
Add conda installation as option

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -42,6 +42,15 @@ The latest release of BayesPy can be installed from PyPI simply as
 .. code-block:: console
     
     pip install bayespy
+    
+Alternatively, you can obtain the latest release with conda 
+(from conda-forge channel). In such case, there is no need to use a virtual 
+environment. Instead, you can install in a conda environment, in any platform,
+with the single command:
+
+.. code-block:: console
+    
+    conda install -c conda-forge bayespy
 
 If you want to install the latest development version of BayesPy, use GitHub
 instead:

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,11 @@ http://opensource.org/licenses/MIT.
    :target: https://gitter.im/bayespy/bayespy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
 .. |release| image:: https://badge.fury.io/py/bayespy.svg
    :target: https://pypi.python.org/pypi/bayespy
+.. |conda-release| image:: https://anaconda.org/conda-forge/bayespy/badges/installer/conda.svg
+   :target: https://anaconda.org/conda-forge/bayespy
 
 ============== =============================================
-Latest release |release|
+Latest release |release| |conda-release|
 Documentation  http://bayespy.org
 Repository     https://github.com/bayespy/bayespy.git
 Bug reports    https://github.com/bayespy/bayespy/issues
@@ -128,5 +130,7 @@ The list of contributors:
 * Christopher Cramer
 
 * Till Hoffmann
+
+Each file or the git log can be used for more detailed information.
 
 Each file or the git log can be used for more detailed information.

--- a/README.rst
+++ b/README.rst
@@ -132,5 +132,3 @@ The list of contributors:
 * Till Hoffmann
 
 Each file or the git log can be used for more detailed information.
-
-Each file or the git log can be used for more detailed information.


### PR DESCRIPTION
Hi, @jluttine and contributors!

Before anything, I must congratulate you for the very nice work done in this package!

I added `bayespy` to conda-forge channel. By now, one can install, in any platform, `bayespy` in a
conda environment just with the following command:

```console
$ conda install -c conda-forge bayespy
```

In this PR, I updated the installation instructions with the above conda installation option. I think it could help people to use this amazing package (including me!).

I hope that this contribution will be appreciated. By the way, @jluttine, as you are the author of this package, do you want to be added as one of the `bayespy`s maintainer in the conda feedstock? I'm the only maintainer right now. However, this is not a problem for me. Conda-forge works almost automatically. When a new version of your package will be released, conda-forge bots will detect it and send a PR to the package's feedstock repo, which I'm the maintainer. The work of the maintainer is to check if requirements of the package changed and merge the PR from the bots. Well, this is basically the maintainer's duty. So, feel free to confirm or decline this invitation!

Best regards,
Diego.