### PR TITLE
Change from scipy to locally defined epsilon

### DIFF
--- a/bayespy/utils/optimize.py
+++ b/bayespy/utils/optimize.py
@@ -8,6 +8,10 @@
 import numpy as np
 from scipy import optimize
 
+
+_epsilon = np.sqrt(np.finfo(float).eps)
+
+
 def minimize(f, x0, maxiter=None, verbose=False):
     """
     Simple wrapper for SciPy's optimize.
@@ -20,7 +24,7 @@ def minimize(f, x0, maxiter=None, verbose=False):
     opt = optimize.minimize(f, x0, jac=True, method='CG', options=options)
     return opt.x
 
-def check_gradient(f, x0, verbose=True, epsilon=optimize.optimize._epsilon, return_abserr=False):
+def check_gradient(f, x0, verbose=True, epsilon=_epsilon, return_abserr=False):
     """
     Simple wrapper for SciPy's gradient checker.
 


### PR DESCRIPTION
BayesPy uses number `scipy.optimize.optimize._epsilon` which doesn't exist is SciPy 1.8.1 (but exists in 1.7.2 at least). 

Replaced in BayesPy with analogous definition (see https://github.com/scipy/scipy/blob/v1.7.2/scipy/optimize/optimize.py#L161)

**A specific consequence of this problem is failure to install the Nix derivation of BayesPy in NixOS.**