### PR TITLE
Fix deprecated numpy types

### DIFF
--- a/bayespy/inference/vmp/nodes/categorical_markov_chain.py
+++ b/bayespy/inference/vmp/nodes/categorical_markov_chain.py
@@ -189,7 +189,7 @@ class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
         # Explicit broadcasting
         P = P * np.ones(plates)[...,None,None,None]
         # Allocate memory
-        Z = np.zeros(plates + (self.N,), dtype=np.int)
+        Z = np.zeros(plates + (self.N,), dtype=np.int64)
         # Draw initial state
         Z[...,0] = random.categorical(p0, size=plates)
         # Create [0,1,2,...,len(plate_axis)] indices for each plate axis and

--- a/bayespy/inference/vmp/nodes/concatenate.py
+++ b/bayespy/inference/vmp/nodes/concatenate.py
@@ -70,7 +70,7 @@ class Concatenate(Deterministic):
         )
 
         # Compute start indices for each parent on the concatenated plate axis
-        self._indices = np.zeros(len(nodes)+1, dtype=np.int)
+        self._indices = np.zeros(len(nodes)+1, dtype=np.int64)
         self._indices[1:] = np.cumsum([int(parent.plates[axis])
                                        for parent in self.parents])
         self._lengths = [parent.plates[axis] for parent in self.parents]

--- a/bayespy/inference/vmp/nodes/tests/test_binomial.py
+++ b/bayespy/inference/vmp/nodes/tests/test_binomial.py
@@ -43,7 +43,7 @@ class TestBinomial(TestCase):
         X = Binomial(10, 0.7*np.ones((4,3)))
         self.assertEqual(X.plates,
                          (4,3))
-        n = np.ones((4,3), dtype=np.int)
+        n = np.ones((4,3), dtype=np.int64)
         X = Binomial(n, 0.7)
         self.assertEqual(X.plates,
                          (4,3))

--- a/bayespy/inference/vmp/nodes/tests/test_multinomial.py
+++ b/bayespy/inference/vmp/nodes/tests/test_multinomial.py
@@ -43,7 +43,7 @@ class TestMultinomial(TestCase):
         X = Multinomial(10, 0.25*np.ones((2,3,4)))
         self.assertEqual(X.plates,
                          (2,3))
-        n = 10 * np.ones((3,4), dtype=np.int)
+        n = 10 * np.ones((3,4), dtype=np.int64)
         X = Multinomial(n, [0.1, 0.3, 0.6])
         self.assertEqual(X.plates,
                          (3,4))

--- a/bayespy/inference/vmp/nodes/tests/test_take.py
+++ b/bayespy/inference/vmp/nodes/tests/test_take.py
@@ -89,7 +89,7 @@ class TestTake(TestCase):
 
         # Test matrix indices, no shape
         X = GaussianARD(1, 1, plates=(3,), shape=(2,))
-        Y = Take(X, np.ones((4, 5), dtype=np.int))
+        Y = Take(X, np.ones((4, 5), dtype=np.int64))
         self.assertEqual(
             Y.plates,
             (4, 5),
@@ -113,7 +113,7 @@ class TestTake(TestCase):
 
         # Test vector indices with more plate axes
         X = GaussianARD(1, 1, plates=(4, 2), shape=())
-        Y = Take(X, np.ones(3, dtype=np.int))
+        Y = Take(X, np.ones(3, dtype=np.int64))
         self.assertEqual(
             Y.plates,
             (4, 3),
@@ -125,7 +125,7 @@ class TestTake(TestCase):
 
         # Test take on other plate axis
         X = GaussianARD(1, 1, plates=(4, 2), shape=())
-        Y = Take(X, np.ones(3, dtype=np.int), plate_axis=-2)
+        Y = Take(X, np.ones(3, dtype=np.int64), plate_axis=-2)
         self.assertEqual(
             Y.plates,
             (3, 2),
@@ -141,7 +141,7 @@ class TestTake(TestCase):
             ValueError,
             Take,
             X,
-            np.ones(3, dtype=np.int),
+            np.ones(3, dtype=np.int64),
             plate_axis=0,
         )
 

--- a/bayespy/utils/tests/test_linalg.py
+++ b/bayespy/utils/tests/test_linalg.py
@@ -126,7 +126,7 @@ class TestBandedSolve(misc.TestCase):
         # Random sizes of the blocks
         #D = np.random.randint(5, 10, size=N)
         # Fixed sizes of the blocks
-        D = 5*np.ones(N, dtype=np.int)
+        D = 5*np.ones(N, dtype=np.int64)
 
         # Some helpful variables to create the covariances
         W = [np.random.randn(D[i], 2*D[i])


### PR DESCRIPTION
np.int has been deprecated since numpy 1.20.0

When creating arrays using np.int64 specifies the array datatype. np.int defaults to python builtin int which depends on the computer and operating system. https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations