### PR TITLE
Change docstrings to raw in main level functions

### DIFF
--- a/bayespy/demos/annealing.py
+++ b/bayespy/demos/annealing.py
@@ -32,7 +32,7 @@ from bayespy.demos import pca
 
 
 def run(N=500, seed=42, maxiter=100, plot=True):
-    """
+    r"""
     Run deterministic annealing demo for 1-D Gaussian mixture.
     """
 
@@ -124,4 +124,3 @@ if __name__ == '__main__':
     run(**kwargs)
 
     plt.show()
-

--- a/bayespy/demos/black_box.py
+++ b/bayespy/demos/black_box.py
@@ -29,7 +29,7 @@ from bayespy.demos import pca
 
 
 def run(M=10, N=100, D=5, seed=42, maxiter=100, plot=True):
-    """
+    r"""
     Run deterministic annealing demo for 1-D Gaussian mixture.
     """
 
@@ -125,4 +125,3 @@ if __name__ == '__main__':
     run(**kwargs)
 
     plt.show()
-

--- a/bayespy/demos/black_box.py
+++ b/bayespy/demos/black_box.py
@@ -49,7 +49,7 @@ def run(M=10, N=100, D=5, seed=42, maxiter=100, plot=True):
 
     # Some arbitrary log likelihood
     def logpdf(y, f):
-        """
+        r"""
         exp(f) / (1 + exp(f)) = 1/(1+exp(-f))
 
         -log(1+exp(-f)) = -log(exp(0)+exp(-f))

--- a/bayespy/demos/collapsed_cg.py
+++ b/bayespy/demos/collapsed_cg.py
@@ -68,7 +68,7 @@ def pca():
 
 
 def mixture_of_gaussians():
-    """Collapsed Riemannian conjugate gradient demo
+    r"""Collapsed Riemannian conjugate gradient demo
 
     This is similar although not exactly identical to an experiment in
     (Hensman et al 2012).

--- a/bayespy/demos/lssm.py
+++ b/bayespy/demos/lssm.py
@@ -32,7 +32,7 @@ import bayespy.plot as bpplt
 
 
 def model(M=10, N=100, D=3):
-    """
+    r"""
     Construct linear state-space model.
 
     See, for instance, the following publication:
@@ -114,7 +114,7 @@ def infer(y, D,
           plot_C=True,
           monitor=True,
           autosave=None):
-    """
+    r"""
     Apply linear state-space model for the given data.
     """
         
@@ -194,7 +194,7 @@ def infer(y, D,
 
 
 def simulate_data(M, N):
-    """
+    r"""
     Generate a dataset using linear state-space model.
 
     The process has two latent oscillation components and one random walk
@@ -224,7 +224,7 @@ def simulate_data(M, N):
 @bpplt.interactive
 def demo(M=6, N=200, D=3, maxiter=100, debug=False, seed=42, rotate=True,
          precompute=False, plot=True, monitor=True):
-    """
+    r"""
     Run the demo for linear state-space model.
     """
 

--- a/bayespy/demos/lssm_sd.py
+++ b/bayespy/demos/lssm_sd.py
@@ -35,7 +35,7 @@ import bayespy.plot as bpplt
 
 
 def model(M=20, N=100, D=10, K=3):
-    """
+    r"""
     Construct the linear state-space model with switching dynamics.
     """
 
@@ -207,7 +207,7 @@ def infer(y, D, K, rotate=False, debug=False, maxiter=100, mask=True,
 
 
 def simulate_data(N):
-    """
+    r"""
     Generate time-series data with switching dynamics.
     """
 
@@ -251,7 +251,7 @@ def simulate_data(N):
 @bpplt.interactive
 def demo(N=1000, maxiter=100, D=3, K=2, seed=42, plot=True, debug=False,
         rotate=False, monitor=True):
-    """
+    r"""
     Run the demo for linear state-space model with switching dynamics.
     """
 

--- a/bayespy/demos/lssm_tvd.py
+++ b/bayespy/demos/lssm_tvd.py
@@ -41,7 +41,7 @@ import bayespy.plot as bpplt
 
 
 def model(M, N, D, K):
-    """
+    r"""
     Construct the linear state-space model with time-varying dynamics
 
     For reference, see the following publication:
@@ -287,7 +287,7 @@ def infer(y, D, K,
 
 
 def simulate_data(N):
-    """
+    r"""
     Generate a signal with changing frequency
     """
 

--- a/bayespy/demos/pattern_search.py
+++ b/bayespy/demos/pattern_search.py
@@ -33,7 +33,7 @@ from bayespy.demos import pca
 
 
 def run(M=40, N=100, D_y=6, D=8, seed=42, rotate=False, maxiter=1000, debug=False, plot=True):
-    """
+    r"""
     Run pattern search demo for PCA.
     """
 
@@ -131,4 +131,3 @@ if __name__ == '__main__':
 
     run(**kwargs)
     plt.show()
-

--- a/bayespy/demos/stochastic_inference.py
+++ b/bayespy/demos/stochastic_inference.py
@@ -33,7 +33,7 @@ from bayespy.demos import pca
 
 
 def run(N=100000, N_batch=50, seed=42, maxiter=100, plot=True):
-    """
+    r"""
     Run deterministic annealing demo for 1-D Gaussian mixture.
     """
 
@@ -177,4 +177,3 @@ if __name__ == '__main__':
     run(**kwargs)
 
     plt.show()
-

--- a/bayespy/discrete_example.py
+++ b/bayespy/discrete_example.py
@@ -13,7 +13,7 @@ FALSE = 0
 TRUE = 1
 
 def _or(p_false, p_true):
-    """
+    r"""
     Build probability table for OR-operation of two parents
 
     p_false: Probability table to use if both are FALSE

--- a/bayespy/inference/vmp/nodes/CovarianceFunctions.py
+++ b/bayespy/inference/vmp/nodes/CovarianceFunctions.py
@@ -502,7 +502,7 @@ class CovarianceFunction(ef.Node):
 
 
     def __call__(self, x1, x2):
-        """ Compute covariance matrix for inputs x1 and x2. """
+        r""" Compute covariance matrix for inputs x1 and x2. """
         covfunc = self.message_to_child()
         return covfunc(x1, x2)[0]
 

--- a/bayespy/inference/vmp/nodes/add.py
+++ b/bayespy/inference/vmp/nodes/add.py
@@ -54,7 +54,7 @@ class Add(Deterministic):
     """
 
     def __init__(self, *nodes, **kwargs):
-        """
+        r"""
         Add(X1, X2, ...)
         """
 
@@ -95,7 +95,7 @@ class Add(Deterministic):
 
 
     def _compute_moments(self, *u_parents):
-        """
+        r"""
         Compute the moments of the sum
         """
 
@@ -114,7 +114,7 @@ class Add(Deterministic):
 
 
     def _compute_message_to_parent(self, index, m, *u_parents):
-        """
+        r"""
         Compute the message to a parent node.
 
         .. math::

--- a/bayespy/inference/vmp/nodes/bernoulli.py
+++ b/bayespy/inference/vmp/nodes/bernoulli.py
@@ -19,7 +19,7 @@ from .node import Moments
 
 
 class BernoulliMoments(BinomialMoments):
-    """
+    r"""
     Class for the moments of Bernoulli variables.
     """
 
@@ -29,7 +29,7 @@ class BernoulliMoments(BinomialMoments):
 
 
 class BernoulliDistribution(BinomialDistribution):
-    """
+    r"""
     Class for the VMP formulas of Bernoulli variables.
     """
 
@@ -114,7 +114,7 @@ from .deterministic import Deterministic
 from .categorical import Categorical, CategoricalMoments
 
 class CategoricalToBernoulli(Deterministic):
-    """
+    r"""
     A node for converting 2-class categorical moments to Bernoulli moments.
     """
 

--- a/bayespy/inference/vmp/nodes/bernoulli.py
+++ b/bayespy/inference/vmp/nodes/bernoulli.py
@@ -75,7 +75,7 @@ class Bernoulli(ExponentialFamily):
 
 
     def __init__(self, p, **kwargs):
-        """
+        r"""
         Create Bernoulli node.
         """
         super().__init__(p, **kwargs)
@@ -83,7 +83,7 @@ class Bernoulli(ExponentialFamily):
 
     @classmethod
     def _constructor(cls, p, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
         """
         p = cls._ensure_moments(p, BetaMoments)
@@ -100,7 +100,7 @@ class Bernoulli(ExponentialFamily):
 
 
     def __str__(self):
-        """
+        r"""
         Print the distribution using standard parameterization.
         """
         p = 1 / (1 + np.exp(-self.phi[0]))
@@ -120,7 +120,7 @@ class CategoricalToBernoulli(Deterministic):
 
     
     def __init__(self, Z, **kwargs):
-        """
+        r"""
         Create a categorical MC moments to categorical moments conversion node.
         """
         # Convert parent to proper type. Z must be a node.
@@ -137,7 +137,7 @@ class CategoricalToBernoulli(Deterministic):
 
         
     def _compute_moments(self, u_Z):
-        """
+        r"""
         Compute the moments given the moments of the parents.
         """
         u0 = u_Z[0][...,0]
@@ -146,7 +146,7 @@ class CategoricalToBernoulli(Deterministic):
 
 
     def _compute_message_to_parent(self, index, m, u_Z):
-        """
+        r"""
         Compute the message to a parent.
         """
         if index == 0:

--- a/bayespy/inference/vmp/nodes/beta.py
+++ b/bayespy/inference/vmp/nodes/beta.py
@@ -21,7 +21,7 @@ from .node import Moments, ensureparents
 
 
 class BetaMoments(DirichletMoments):
-    """
+    r"""
     Class for the moments of beta variables.
     """
 
@@ -48,7 +48,7 @@ class BetaMoments(DirichletMoments):
 
 
 class BetaDistribution(DirichletDistribution):
-    """
+    r"""
     Class for the VMP formulas of beta variables.
 
     Although the realizations are scalars (probability p), the moments is a
@@ -189,7 +189,7 @@ class Beta(Dirichlet):
 
 
 class Complement(Deterministic):
-    """
+    r"""
     Perform 1-p where p is a Beta node.
     """
 

--- a/bayespy/inference/vmp/nodes/beta.py
+++ b/bayespy/inference/vmp/nodes/beta.py
@@ -31,7 +31,7 @@ class BetaMoments(DirichletMoments):
 
 
     def compute_fixed_moments(self, p):
-        """
+        r"""
         Compute the moments for a fixed value
         """
         p = np.asanyarray(p)[...,None] * [1,-1] + [0,1]
@@ -41,7 +41,7 @@ class BetaMoments(DirichletMoments):
 
     @classmethod
     def from_values(cls, p):
-        """
+        r"""
         Return the shape of the moments for a fixed value.
         """
         return cls()
@@ -57,35 +57,35 @@ class BetaDistribution(DirichletDistribution):
 
 
     def compute_message_to_parent(self, parent, index, u_self, u_alpha):
-        """
+        r"""
         Compute the message to a parent node.
         """
         return super().compute_message_to_parent(parent, index, u_self, u_alpha)
 
     
     def compute_phi_from_parents(self, u_alpha, mask=True):
-        """
+        r"""
         Compute the natural parameter vector given parent moments.
         """
         return super().compute_phi_from_parents(u_alpha, mask=mask)
 
     
     def compute_moments_and_cgf(self, phi, mask=True):
-        """
+        r"""
         Compute the moments and :math:`g(\phi)`.
         """
         return super().compute_moments_and_cgf(phi, mask)
 
     
     def compute_cgf_from_parents(self, u_alpha):
-        """
+        r"""
         Compute :math:`\mathrm{E}_{q(p)}[g(p)]`
         """
         return super().compute_cgf_from_parents(u_alpha)
 
     
     def compute_fixed_moments_and_f(self, p, mask=True):
-        """
+        r"""
         Compute the moments and :math:`f(x)` for a fixed value.
         """
         p = np.asanyarray(p)[...,None] * [1,-1] + [0,1]
@@ -93,7 +93,7 @@ class BetaDistribution(DirichletDistribution):
 
 
     def random(self, *phi, plates=None):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         p = super().random(*phi, plates=plates)
@@ -141,7 +141,7 @@ class Beta(Dirichlet):
 
 
     def __init__(self, alpha, **kwargs):
-        """
+        r"""
         Create beta node
         """
         super().__init__(alpha, **kwargs)
@@ -149,7 +149,7 @@ class Beta(Dirichlet):
 
     @classmethod
     def _constructor(cls, alpha, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
         """
 
@@ -175,7 +175,7 @@ class Beta(Dirichlet):
 
 
     def __str__(self):
-        """
+        r"""
         Print the distribution using standard parameterization.
         """
         a = self.phi[0][...,0]

--- a/bayespy/inference/vmp/nodes/binomial.py
+++ b/bayespy/inference/vmp/nodes/binomial.py
@@ -27,7 +27,7 @@ from bayespy.utils import misc, random
 
 
 class BinomialMoments(PoissonMoments):
-    """
+    r"""
     Class for the moments of binomial variables
     """
 
@@ -59,7 +59,7 @@ class BinomialMoments(PoissonMoments):
 
 
 class BinomialDistribution(ExponentialFamilyDistribution):
-    """
+    r"""
     Class for the VMP formulas of binomial variables.
     """
 

--- a/bayespy/inference/vmp/nodes/binomial.py
+++ b/bayespy/inference/vmp/nodes/binomial.py
@@ -38,7 +38,7 @@ class BinomialMoments(PoissonMoments):
 
 
     def compute_fixed_moments(self, x):
-        """
+        r"""
         Compute the moments for a fixed value
         """
         # Make sure the values are integers in valid range
@@ -49,7 +49,7 @@ class BinomialMoments(PoissonMoments):
 
 
     def compute_dims_from_values(self, x):
-        """
+        r"""
         Return the shape of the moments for a fixed value.
 
         The realizations are scalars, thus the shape of the moment is ().
@@ -75,7 +75,7 @@ class BinomialDistribution(ExponentialFamilyDistribution):
 
 
     def compute_message_to_parent(self, parent, index, u_self, u_p):
-        """
+        r"""
         Compute the message to a parent node.
         """
         if index == 0:
@@ -89,7 +89,7 @@ class BinomialDistribution(ExponentialFamilyDistribution):
 
 
     def compute_phi_from_parents(self, u_p, mask=True):
-        """
+        r"""
         Compute the natural parameter vector given parent moments.
         """
         logp0 = u_p[0][...,0]
@@ -99,7 +99,7 @@ class BinomialDistribution(ExponentialFamilyDistribution):
 
 
     def compute_moments_and_cgf(self, phi, mask=True):
-        """
+        r"""
         Compute the moments and :math:`g(\phi)`.
         """
         u0 = self.N / (1 + np.exp(-phi[0]))
@@ -108,7 +108,7 @@ class BinomialDistribution(ExponentialFamilyDistribution):
 
 
     def compute_cgf_from_parents(self, u_p):
-        """
+        r"""
         Compute :math:`\mathrm{E}_{q(p)}[g(p)]`
         """
         logp0 = u_p[0][...,0]
@@ -117,7 +117,7 @@ class BinomialDistribution(ExponentialFamilyDistribution):
 
 
     def compute_fixed_moments_and_f(self, x, mask=True):
-        """
+        r"""
         Compute the moments and :math:`f(x)` for a fixed value.
         """
         # Make sure the values are integers in valid range
@@ -135,7 +135,7 @@ class BinomialDistribution(ExponentialFamilyDistribution):
 
 
     def random(self, *phi, plates=None):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         p = random.logodds_to_probability(phi[0])
@@ -205,7 +205,7 @@ class Binomial(ExponentialFamily):
 
 
     def __init__(self, n, p, **kwargs):
-        """
+        r"""
         Create binomial node
         """
         super().__init__(n, p, **kwargs)
@@ -213,7 +213,7 @@ class Binomial(ExponentialFamily):
 
     @classmethod
     def _constructor(cls, n, p, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
         """
         p = cls._ensure_moments(p, BetaMoments)
@@ -233,7 +233,7 @@ class Binomial(ExponentialFamily):
 
 
     def __str__(self):
-        """
+        r"""
         Print the distribution using standard parameterization.
         """
         p = 1 / (1 + np.exp(-self.phi[0]))

--- a/bayespy/inference/vmp/nodes/categorical.py
+++ b/bayespy/inference/vmp/nodes/categorical.py
@@ -23,7 +23,7 @@ from bayespy.utils import misc
 
 
 class CategoricalMoments(MultinomialMoments):
-    """
+    r"""
     Class for the moments of categorical variables.
     """
 
@@ -72,7 +72,7 @@ class CategoricalMoments(MultinomialMoments):
 
 
 class CategoricalDistribution(MultinomialDistribution):
-    """
+    r"""
     Class for the VMP formulas of categorical variables.
     """
 

--- a/bayespy/inference/vmp/nodes/categorical.py
+++ b/bayespy/inference/vmp/nodes/categorical.py
@@ -28,7 +28,7 @@ class CategoricalMoments(MultinomialMoments):
     """
 
     def compute_fixed_moments(self, x):
-        """
+        r"""
         Compute the moments for a fixed value
         """
 
@@ -48,7 +48,7 @@ class CategoricalMoments(MultinomialMoments):
 
     @classmethod
     def from_values(cls, x, categories):
-        """
+        r"""
         Return the shape of the moments for a fixed value.
 
         The observations are scalar.
@@ -77,7 +77,7 @@ class CategoricalDistribution(MultinomialDistribution):
     """
 
     def __init__(self, categories):
-        """
+        r"""
         Create VMP formula node for a categorical variable
 
         `categories` is the total number of categories.
@@ -91,7 +91,7 @@ class CategoricalDistribution(MultinomialDistribution):
 
 
     def compute_fixed_moments_and_f(self, x, mask=True):
-        """
+        r"""
         Compute the moments and :math:`f(x)` for a fixed value.
         """
 
@@ -115,7 +115,7 @@ class CategoricalDistribution(MultinomialDistribution):
 
 
     def random(self, *phi, plates=None):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         logp = phi[0]
@@ -152,7 +152,7 @@ class Categorical(ExponentialFamily):
 
 
     def __init__(self, p, **kwargs):
-        """
+        r"""
         Create Categorical node.
         """
         super().__init__(p, **kwargs)
@@ -160,7 +160,7 @@ class Categorical(ExponentialFamily):
 
     @classmethod
     def _constructor(cls, p, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
 
         This method is called if useconstructor decorator is used for __init__.
@@ -191,7 +191,7 @@ class Categorical(ExponentialFamily):
 
 
     def __str__(self):
-        """
+        r"""
         Print the distribution using standard parameterization.
         """
         p = self.u[0]

--- a/bayespy/inference/vmp/nodes/categorical_markov_chain.py
+++ b/bayespy/inference/vmp/nodes/categorical_markov_chain.py
@@ -24,7 +24,7 @@ from .dirichlet import (Dirichlet,
 from bayespy.utils import misc, random
 
 class CategoricalMarkovChainMoments(Moments):
-    """
+    r"""
     Class for the moments of categorical Markov chain variables.
     """
 
@@ -77,7 +77,7 @@ class CategoricalMarkovChainMoments(Moments):
 
 
 class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
-    """
+    r"""
     Class for the VMP formulas of categorical Markov chain variables.
     """
 
@@ -358,7 +358,7 @@ class CategoricalMarkovChain(ExponentialFamily):
 
 
 class CategoricalMarkovChainToCategorical(Deterministic):
-    """
+    r"""
     A node for converting categorical MC moments to categorical moments.
     """
 

--- a/bayespy/inference/vmp/nodes/categorical_markov_chain.py
+++ b/bayespy/inference/vmp/nodes/categorical_markov_chain.py
@@ -30,7 +30,7 @@ class CategoricalMarkovChainMoments(Moments):
 
 
     def __init__(self, categories, length):
-        """
+        r"""
         Create moments object for categorical Markov chain variables.
         """
         self.categories = categories
@@ -40,7 +40,7 @@ class CategoricalMarkovChainMoments(Moments):
 
 
     def compute_fixed_moments(self, x):
-        """
+        r"""
         Compute the moments for a fixed value
         """
 
@@ -68,7 +68,7 @@ class CategoricalMarkovChainMoments(Moments):
 
     @classmethod
     def from_values(cls, x, categories):
-        """
+        r"""
         Return the shape of the moments for a fixed value.
         """
         raise NotImplementedError("from_values not implemented "
@@ -83,7 +83,7 @@ class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
 
 
     def __init__(self, categories, states):
-        """
+        r"""
         Create VMP formula node for a categorical variable
 
         `categories` is the total number of categories.
@@ -93,7 +93,7 @@ class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
         self.N = states
 
     def compute_message_to_parent(self, parent, index, u, u_p0, u_P):
-        """
+        r"""
         Compute the message to a parent node.
         """
         if index == 0:
@@ -104,7 +104,7 @@ class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
             raise ValueError("Parent index out of bounds")
 
     def compute_weights_to_parent(self, index, weights):
-        """
+        r"""
         Maps the mask to the plates of a parent.
         """
         if index == 0:
@@ -117,7 +117,7 @@ class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
             raise ValueError("Parent index out of bounds")
 
     def compute_phi_from_parents(self, u_p0, u_P, mask=True):
-        """
+        r"""
         Compute the natural parameter vector given parent moments.
         """
         phi0 = u_p0[0]
@@ -125,7 +125,7 @@ class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
         return [phi0, phi1]
 
     def compute_moments_and_cgf(self, phi, mask=True):
-        """
+        r"""
         Compute the moments and :math:`g(\phi)`.
         """
         logp0 = phi[0]
@@ -135,19 +135,19 @@ class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
         return (u, cgf)
 
     def compute_cgf_from_parents(self, u_p0, u_P):
-        """
+        r"""
         Compute :math:`\mathrm{E}_{q(p)}[g(p)]`
         """
         return 0
 
     def compute_fixed_moments_and_f(self, x, mask=True):
-        """
+        r"""
         Compute the moments and :math:`f(x)` for a fixed value.
         """
         raise NotImplementedError()
 
     def plates_to_parent(self, index, plates):
-        """
+        r"""
         Resolves the plate mapping to a parent.
 
         Given the plates of the node's moments, this method returns the plates
@@ -161,7 +161,7 @@ class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
             raise ValueError("Parent index out of bounds")
 
     def plates_from_parent(self, index, plates):
-        """
+        r"""
         Resolve the plate mapping from a parent.
 
         Given the plates of a parent's moments, this method returns the plates
@@ -176,7 +176,7 @@ class CategoricalMarkovChainDistribution(ExponentialFamilyDistribution):
 
 
     def random(self, *phi, plates=None):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         # Convert natural parameters to transition probabilities
@@ -287,7 +287,7 @@ class CategoricalMarkovChain(ExponentialFamily):
 
 
     def __init__(self, pi, A, states=None, **kwargs):
-        """
+        r"""
         Create categorical Markov chain
         """
         super().__init__(pi, A, states=states, **kwargs)
@@ -295,7 +295,7 @@ class CategoricalMarkovChain(ExponentialFamily):
 
     @classmethod
     def _constructor(cls, p0, P, states=None, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
 
         This method is called if useconstructor decorator is used for __init__.
@@ -364,7 +364,7 @@ class CategoricalMarkovChainToCategorical(Deterministic):
 
 
     def __init__(self, Z, **kwargs):
-        """
+        r"""
         Create a categorical MC moments to categorical moments conversion node.
         """
         # Convert parent to proper type. Z must be a node.
@@ -377,7 +377,7 @@ class CategoricalMarkovChainToCategorical(Deterministic):
 
 
     def _compute_moments(self, u_Z):
-        """
+        r"""
         Compute the moments given the moments of the parents.
         """
         # Add time axis to p0
@@ -399,7 +399,7 @@ class CategoricalMarkovChainToCategorical(Deterministic):
         return [P]
 
     def _compute_message_to_parent(self, index, m, u_Z):
-        """
+        r"""
         Compute the message to a parent.
         """
         m0 = m[0][...,0,:]
@@ -408,7 +408,7 @@ class CategoricalMarkovChainToCategorical(Deterministic):
 
 
     def _compute_weights_to_parent(self, index, weights):
-        """
+        r"""
         Compute the mask used for messages sent to a parent.
         """
         if index == 0:

--- a/bayespy/inference/vmp/nodes/concat_gaussian.py
+++ b/bayespy/inference/vmp/nodes/concat_gaussian.py
@@ -7,7 +7,7 @@ from .deterministic import Deterministic
 
 
 class ConcatGaussian(Deterministic):
-    """Concatenate Gaussian vectors along the variable axis (not plate axis)
+    r"""Concatenate Gaussian vectors along the variable axis (not plate axis)
 
     NOTE: This concatenates on the variable axis! That is, the dimensionality
     of the resulting Gaussian vector is the sum of the dimensionalities of the

--- a/bayespy/inference/vmp/nodes/concatenate.py
+++ b/bayespy/inference/vmp/nodes/concatenate.py
@@ -13,7 +13,7 @@ from .deterministic import Deterministic
 from .node import Moments
 
 class Concatenate(Deterministic):
-    """
+    r"""
     Concatenate similar nodes along a plate axis.
 
     Nodes must be of same type and dimensionality. Also, plates must be

--- a/bayespy/inference/vmp/nodes/concatenate.py
+++ b/bayespy/inference/vmp/nodes/concatenate.py
@@ -78,7 +78,7 @@ class Concatenate(Deterministic):
 
 
     def _get_id_list(self):
-        """
+        r"""
         Parents don't need to be independent for this node so remove duplicates
         """
         return list(set(super()._get_id_list()))

--- a/bayespy/inference/vmp/nodes/constant.py
+++ b/bayespy/inference/vmp/nodes/constant.py
@@ -39,7 +39,7 @@ class Constant(Node):
 
 
     def _get_id_list(self):
-        """
+        r"""
         Returns the stochastic ID list.
 
         This method is used to check that same stochastic nodes are not direct

--- a/bayespy/inference/vmp/nodes/converters.py
+++ b/bayespy/inference/vmp/nodes/converters.py
@@ -5,7 +5,7 @@ from .deterministic import Deterministic
 
 
 class NodeConverter(Deterministic):
-    """
+    r"""
     Simple wrapper to transform moment converters into nodes
     """
 

--- a/bayespy/inference/vmp/nodes/deterministic.py
+++ b/bayespy/inference/vmp/nodes/deterministic.py
@@ -14,7 +14,7 @@ from bayespy.utils import misc
 from .node import Node, Moments
 
 class Deterministic(Node):
-    """
+    r"""
     Base class for deterministic nodes.
 
     Sub-classes must implement:
@@ -154,7 +154,7 @@ class Deterministic(Node):
 
 
 def tile(X, tiles):
-    """
+    r"""
     Tile the plates of the input node.
 
     x = [a,b,c]

--- a/bayespy/inference/vmp/nodes/deterministic.py
+++ b/bayespy/inference/vmp/nodes/deterministic.py
@@ -39,7 +39,7 @@ class Deterministic(Node):
         super().__init__(*args, plates=None, notify_parents=False, **kwargs)
 
     def _get_id_list(self):
-        """
+        r"""
         Returns the stochastic ID list.
 
         This method is used to check that same stochastic nodes are not direct
@@ -83,21 +83,21 @@ class Deterministic(Node):
         
 
     def _compute_moments(self, *u_parents):
-        """
+        r"""
         Compute the moments given the moments of the parents.
         """
         raise NotImplementedError()
 
 
     def _compute_message_to_parent(self, index, m_children, *u_parents):
-        """
+        r"""
         Compute the message to a parent.
         """
         raise NotImplementedError()
 
     
     def _add_child(self, child, index):
-        """
+        r"""
         Add a child node.
 
         Only child nodes that are stochastic (or have stochastic children
@@ -125,7 +125,7 @@ class Deterministic(Node):
             parent._add_child(self, ind)
 
     def _remove_child(self, child, index):
-        """
+        r"""
         Remove a child node.
 
         Only child nodes that are stochastic (or have stochastic children
@@ -287,7 +287,7 @@ def tile(X, tiles):
             return m
 
         def _compute_moments(self, u_X):
-            """
+            r"""
             Tile the plates of the parent's moments.
             """
             # Utilize broadcasting: If a tiled axis is unit length in u_X, there

--- a/bayespy/inference/vmp/nodes/dirichlet.py
+++ b/bayespy/inference/vmp/nodes/dirichlet.py
@@ -23,7 +23,7 @@ from .node import Node, Moments, ensureparents
 
 
 class ConcentrationMoments(Moments):
-    """
+    r"""
     Class for the moments of Dirichlet conjugate-prior variables.
     """
 
@@ -63,7 +63,7 @@ class ConcentrationMoments(Moments):
 
 
 class DirichletMoments(Moments):
-    """
+    r"""
     Class for the moments of Dirichlet variables.
     """
 
@@ -105,7 +105,7 @@ class DirichletMoments(Moments):
 
 
 class DirichletDistribution(ExponentialFamilyDistribution):
-    """
+    r"""
     Class for the VMP formulas of Dirichlet variables.
     """
 

--- a/bayespy/inference/vmp/nodes/dirichlet.py
+++ b/bayespy/inference/vmp/nodes/dirichlet.py
@@ -35,7 +35,7 @@ class ConcentrationMoments(Moments):
 
 
     def compute_fixed_moments(self, alpha):
-        """
+        r"""
         Compute the moments for a fixed value
         """
 
@@ -53,7 +53,7 @@ class ConcentrationMoments(Moments):
 
     @classmethod
     def from_values(cls, alpha):
-        """
+        r"""
         Return the shape of the moments for a fixed value.
         """
         if np.ndim(alpha) < 1:
@@ -74,7 +74,7 @@ class DirichletMoments(Moments):
 
 
     def compute_fixed_moments(self, p):
-        """
+        r"""
         Compute the moments for a fixed value
         """
         # Check that probabilities are non-negative
@@ -95,7 +95,7 @@ class DirichletMoments(Moments):
 
     @classmethod
     def from_values(cls, x):
-        """
+        r"""
         Return the shape of the moments for a fixed value.
         """
         if np.ndim(x) < 1:
@@ -238,7 +238,7 @@ class Concentration(Stochastic):
 
 
     def __init__(self, D, regularization=True, **kwargs):
-        """
+        r"""
         ML estimation node for concentration parameters.
 
         Parameters
@@ -366,7 +366,7 @@ class Dirichlet(ExponentialFamily):
 
     @classmethod
     def _constructor(cls, alpha, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
         """
         # Number of categories
@@ -390,7 +390,7 @@ class Dirichlet(ExponentialFamily):
 
 
     def __str__(self):
-        """
+        r"""
         Show distribution as a string
         """
         alpha = self.phi[0]

--- a/bayespy/inference/vmp/nodes/dot.py
+++ b/bayespy/inference/vmp/nodes/dot.py
@@ -634,7 +634,7 @@ class SumMultiply(Deterministic):
 
 
 def Dot(*args, **kwargs):
-    """
+    r"""
     Node for computing inner product of several Gaussian vectors.
 
     This is a simple wrapper of the much more general SumMultiply. For now, it

--- a/bayespy/inference/vmp/nodes/dot.py
+++ b/bayespy/inference/vmp/nodes/dot.py
@@ -111,7 +111,7 @@ class SumMultiply(Deterministic):
     """
 
     def __init__(self, *args, iterator_axis=None, **kwargs):
-        """
+        r"""
         SumMultiply(Node1, map1, Node2, map2, ..., NodeN, mapN [, map_out])
         """
 
@@ -423,7 +423,7 @@ class SumMultiply(Deterministic):
 
 
     def _message_to_parent(self, index, u_parent=None):
-        """
+        r"""
         Compute the message and mask to a parent node.
         """
 

--- a/bayespy/inference/vmp/nodes/expfamily.py
+++ b/bayespy/inference/vmp/nodes/expfamily.py
@@ -15,7 +15,7 @@ from .node import ensureparents
 from .stochastic import Stochastic, Distribution
 
 class ExponentialFamilyDistribution(Distribution):
-    """
+    r"""
     Sub-classes implement distribution specific computations.
     """
 
@@ -92,7 +92,7 @@ def useconstructor(__init__):
     return constructor_decorator
 
 class ExponentialFamily(Stochastic):
-    """
+    r"""
     A base class for nodes using natural parameterization `phi`.
 
     phi

--- a/bayespy/inference/vmp/nodes/expfamily.py
+++ b/bayespy/inference/vmp/nodes/expfamily.py
@@ -43,7 +43,7 @@ class ExponentialFamilyDistribution(Distribution):
         raise NotImplementedError()
 
     def compute_logpdf(self, u, phi, g, f, ndims):
-        """ Compute E[log p(X)] given E[u], E[phi], E[g] and
+        r""" Compute E[log p(X)] given E[u], E[phi], E[g] and
         E[f]. Does not sum over plates."""
 
         # TODO/FIXME: Should I take into account what is latent or
@@ -141,7 +141,7 @@ class ExponentialFamily(Stochastic):
     @classmethod
     @ensureparents
     def _constructor(cls, *parents, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
 
         If __init__ uses useconstructor decorator, this method is called to
@@ -204,7 +204,7 @@ class ExponentialFamily(Stochastic):
         self._set_moments_and_cgf(u, np.inf, mask=mask)
 
     def initialize_from_random(self):
-        """
+        r"""
         Set the variable to a random sample from the current distribution.
         """
         #self.initialize_from_prior()
@@ -353,7 +353,7 @@ class ExponentialFamily(Stochastic):
 
 
     def _update_moments_and_cgf(self):
-        """
+        r"""
         Update moments and cgf based on current phi.
         """
         # Mask for plates to update (i.e., unobserved plates)
@@ -367,7 +367,7 @@ class ExponentialFamily(Stochastic):
 
 
     def observe(self, x, *args, mask=True):
-        """
+        r"""
         Fix moments, compute f and propagate mask.
         """
 
@@ -481,7 +481,7 @@ class ExponentialFamily(Stochastic):
 
 
     def logpdf(self, X, mask=True):
-        """
+        r"""
         Compute the log probability density function Q(X) of this node.
         """
         if mask is not True:
@@ -498,14 +498,14 @@ class ExponentialFamily(Stochastic):
 
 
     def pdf(self, X, mask=True):
-        """
+        r"""
         Compute the probability density function of this node.
         """
         return np.exp(self.logpdf(X, mask=mask))
 
 
     def _save(self, group):
-        """
+        r"""
         Save the state of the node into a HDF5 file.
 
         group can be the root
@@ -522,7 +522,7 @@ class ExponentialFamily(Stochastic):
 
 
     def _load(self, group):
-        """
+        r"""
         Load the state of the node from a HDF5 file.
         """
         # TODO/FIXME: Check that the shapes are correct!
@@ -536,7 +536,7 @@ class ExponentialFamily(Stochastic):
 
 
     def random(self):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         return self._distribution.random(*(self.phi), plates=self.plates)

--- a/bayespy/inference/vmp/nodes/gamma.py
+++ b/bayespy/inference/vmp/nodes/gamma.py
@@ -23,7 +23,7 @@ from bayespy.utils import random
 
 
 def diagonal(alpha):
-    """
+    r"""
     Create a diagonal Wishart node from a Gamma node.
     """
     return _GammaToDiagonalWishart(alpha,
@@ -31,7 +31,7 @@ def diagonal(alpha):
 
 
 class GammaPriorMoments(Moments):
-    """
+    r"""
     Class for the moments of the shape parameter in gamma distributions.
     """
 
@@ -60,7 +60,7 @@ class GammaPriorMoments(Moments):
 
 
 class GammaMoments(Moments):
-    """
+    r"""
     Class for the moments of gamma variables.
     """
 
@@ -88,7 +88,7 @@ class GammaMoments(Moments):
 
 
 class GammaDistribution(ExponentialFamilyDistribution):
-    """
+    r"""
     Class for the VMP formulas of gamma variables.
     """
 
@@ -212,7 +212,7 @@ class GammaDistribution(ExponentialFamilyDistribution):
 
 
 class Gamma(ExponentialFamily):
-    """
+    r"""
     Node for gamma random variables.
 
     Parameters
@@ -271,7 +271,7 @@ class Gamma(ExponentialFamily):
 
 
 class GammaShape(Stochastic):
-    """
+    r"""
     ML point estimator for the shape parameter of the gamma distribution
     """
 
@@ -335,7 +335,7 @@ class GammaShape(Stochastic):
 
 
 class _GammaToDiagonalWishart(Deterministic):
-    """
+    r"""
     Transform a set of gamma scalars into a diagonal Wishart matrix.
 
     The last plate is used as the diagonal dimension.
@@ -397,7 +397,7 @@ class _GammaToDiagonalWishart(Deterministic):
 
 
 class _GammaToScalarWishart(Deterministic):
-    """
+    r"""
     Transform gamma scalar moments to ndim=0 scalar Wishart moments
     """
 

--- a/bayespy/inference/vmp/nodes/gamma.py
+++ b/bayespy/inference/vmp/nodes/gamma.py
@@ -40,7 +40,7 @@ class GammaPriorMoments(Moments):
 
 
     def compute_fixed_moments(self, a):
-        """
+        r"""
         Compute the moments for a fixed value
         """
         a = np.asanyarray(a)
@@ -53,7 +53,7 @@ class GammaPriorMoments(Moments):
 
     @classmethod
     def from_values(cls, a):
-        """
+        r"""
         Return the shape of the moments for a fixed value.
         """
         return cls()
@@ -68,7 +68,7 @@ class GammaMoments(Moments):
 
 
     def compute_fixed_moments(self, x):
-        """
+        r"""
         Compute the moments for a fixed value
         """
         x = np.asanyarray(x)
@@ -81,7 +81,7 @@ class GammaMoments(Moments):
 
     @classmethod
     def from_values(cls, x):
-        """
+        r"""
         Return the shape of the moments for a fixed value.
         """
         return cls()
@@ -235,14 +235,14 @@ class Gamma(ExponentialFamily):
 
 
     def __init__(self, a, b, **kwargs):
-        """
+        r"""
         Create gamma random variable node
         """
         super().__init__(a, b, **kwargs)
 
 
     def __str__(self):
-        """
+        r"""
         Print the distribution using standard parameterization.
         """
         a = self.phi[1]
@@ -281,7 +281,7 @@ class GammaShape(Stochastic):
 
 
     def __init__(self, m0=0, m1=0, **kwargs):
-        """
+        r"""
         Create gamma random variable node
         """
         super().__init__(dims=self.dims, initialize=False, **kwargs)

--- a/bayespy/inference/vmp/nodes/gate.py
+++ b/bayespy/inference/vmp/nodes/gate.py
@@ -19,7 +19,7 @@ from .concatenate import Concatenate
 
 
 class Gate(Deterministic):
-    """
+    r"""
     Deterministic gating of one node.
 
     Gating is performed over one plate axis.
@@ -217,7 +217,7 @@ class Gate(Deterministic):
 
 
 def Choose(z, *nodes):
-    """Choose plate elements from nodes based on a categorical variable.
+    r"""Choose plate elements from nodes based on a categorical variable.
 
     For instance:
 

--- a/bayespy/inference/vmp/nodes/gate.py
+++ b/bayespy/inference/vmp/nodes/gate.py
@@ -32,7 +32,7 @@ class Gate(Deterministic):
     """
 
     def __init__(self, Z, X, gated_plate=-1, moments=None, **kwargs):
-        """
+        r"""
         Constructor for the gating node.
 
         Parameters
@@ -84,7 +84,7 @@ class Gate(Deterministic):
 
 
     def _compute_moments(self, u_Z, u_X):
-        """
+        r"""
         """
 
         u = []
@@ -106,7 +106,7 @@ class Gate(Deterministic):
 
 
     def _compute_message_to_parent(self, index, m_child, u_Z, u_X):
-        """
+        r"""
         """
         if index == 0:
             m0 = 0
@@ -166,7 +166,7 @@ class Gate(Deterministic):
 
 
     def _compute_weights_to_parent(self, index, weights):
-        """
+        r"""
         """
         if index == 0:
             return weights
@@ -183,7 +183,7 @@ class Gate(Deterministic):
 
 
     def _compute_plates_to_parent(self, index, plates):
-        """
+        r"""
         """
         if index == 0:
             return plates
@@ -202,7 +202,7 @@ class Gate(Deterministic):
 
 
     def _compute_plates_from_parent(self, index, plates):
-        """
+        r"""
         """
         if index == 0:
             return plates

--- a/bayespy/inference/vmp/nodes/gaussian.py
+++ b/bayespy/inference/vmp/nodes/gaussian.py
@@ -1286,7 +1286,7 @@ class _GaussianTemplate(ExponentialFamily):
 
 
     def translate(self, b, debug=False):
-        """
+        r"""
         Transforms the current posterior by adding a bias to the mean
 
         Parameters

--- a/bayespy/inference/vmp/nodes/gaussian_markov_chain.py
+++ b/bayespy/inference/vmp/nodes/gaussian_markov_chain.py
@@ -66,7 +66,7 @@ class GaussianMarkovChainMoments(Moments):
 
 
 class TemplateGaussianMarkovChainDistribution(ExponentialFamilyDistribution):
-    """
+    r"""
     Sub-classes implement distribution specific computations.
     """
 
@@ -250,7 +250,7 @@ class _TemplateGaussianMarkovChain(ExponentialFamily):
 
 def _compute_cgf_for_gaussian_markov_chain(mumu_Lambda, logdet_Lambda,
                                            logdet_nu, N):
-    """
+    r"""
     Compute CGF using the moments of the parents.
     """
 
@@ -928,7 +928,7 @@ class GaussianMarkovChain(_TemplateGaussianMarkovChain):
 
 
 class VaryingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribution):
-    """
+    r"""
     Sub-classes implement distribution specific computations.
     """
 
@@ -1452,7 +1452,7 @@ class VaryingGaussianMarkovChain(_TemplateGaussianMarkovChain):
 
 
 class SwitchingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribution):
-    """
+    r"""
     Sub-classes implement distribution specific computations.
     """
 
@@ -1986,7 +1986,7 @@ class SwitchingGaussianMarkovChain(_TemplateGaussianMarkovChain):
 
 
 class _MarkovChainToGaussian(Deterministic):
-    """
+    r"""
     Transform a Gaussian Markov chain node into a Gaussian node.
 
     This node is deterministic.

--- a/bayespy/inference/vmp/nodes/gaussian_markov_chain.py
+++ b/bayespy/inference/vmp/nodes/gaussian_markov_chain.py
@@ -87,7 +87,7 @@ class TemplateGaussianMarkovChainDistribution(ExponentialFamilyDistribution):
         raise NotImplementedError()
 
     def compute_moments_and_cgf(self, phi, mask=True):
-        """
+        r"""
         Compute the moments and the cumulant-generating function.
 
         This basically performs the filtering and smoothing for the variable.
@@ -126,7 +126,7 @@ class TemplateGaussianMarkovChainDistribution(ExponentialFamilyDistribution):
         raise NotImplementedError()
 
     def compute_fixed_moments_and_f(self, x, mask=True):
-        """
+        r"""
         Compute u(x) and f(x) for given x.
         """
         u0 = x
@@ -138,7 +138,7 @@ class TemplateGaussianMarkovChainDistribution(ExponentialFamilyDistribution):
         return (u, f)
 
     def plates_to_parent(self, index, plates):
-        """
+        r"""
         Computes the plates of this node with respect to a parent.
 
         Child classes must implement this.
@@ -151,7 +151,7 @@ class TemplateGaussianMarkovChainDistribution(ExponentialFamilyDistribution):
         raise NotImplementedError()
 
     def plates_from_parent(self, index, plates):
-        """
+        r"""
         Compute the plates using information of a parent node.
 
         Child classes must implement this.
@@ -540,7 +540,7 @@ class GaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribution):
 
 
     def compute_phi_from_parents(self, u_mu_Lambda, u_A_nu, *u_inputs, mask=True):
-        """
+        r"""
         Compute the natural parameters using parents' moments.
 
         Parameters
@@ -627,7 +627,7 @@ class GaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribution):
         return (phi0, phi1, phi2)
 
     def compute_cgf_from_parents(self, u_mu_Lambda, u_A_nu, *u_inputs):
-        """
+        r"""
         Compute CGF using the moments of the parents.
         """
         g = _compute_cgf_for_gaussian_markov_chain(u_mu_Lambda[1],
@@ -658,7 +658,7 @@ class GaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribution):
 
 
     def plates_to_parent(self, index, plates):
-        """
+        r"""
         Computes the plates of this node with respect to a parent.
 
         If this node has plates (...), the latent dimensionality is D
@@ -683,7 +683,7 @@ class GaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribution):
             raise ValueError("Invalid parent index.")
 
     def plates_from_parent(self, index, plates):
-        """
+        r"""
         Compute the plates using information of a parent node.
 
         If the plates of the parents are:
@@ -786,7 +786,7 @@ class GaussianMarkovChain(_TemplateGaussianMarkovChain):
 
 
     def __init__(self, mu, Lambda, A, nu, n=None, inputs=None, **kwargs):
-        """
+        r"""
         Create GaussianMarkovChain node.
         """
         super().__init__(mu, Lambda, A, nu, n=n, inputs=inputs, **kwargs)
@@ -794,7 +794,7 @@ class GaussianMarkovChain(_TemplateGaussianMarkovChain):
 
     @classmethod
     def _constructor(cls, mu, Lambda, A, nu, n=None, inputs=None, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
 
         Compute the dimensions of phi and u.
@@ -935,7 +935,7 @@ class VaryingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribu
 
     def compute_message_to_parent(self, parent, index, u, u_mu, u_Lambda, u_B,
                                    u_S, u_v):
-        """
+        r"""
         Compute a message to a parent.
 
         Parameters
@@ -1037,7 +1037,7 @@ class VaryingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribu
 
     def compute_phi_from_parents(self, u_mu, u_Lambda, u_B, u_S, u_v,
                                  mask=True):
-        """
+        r"""
         Compute the natural parameters using parents' moments.
 
         Parameters
@@ -1122,7 +1122,7 @@ class VaryingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribu
         return (phi0, phi1, phi2)
 
     def compute_cgf_from_parents(self, u_mu, u_Lambda, u_B, u_S, u_v):
-        """
+        r"""
         Compute CGF using the moments of the parents.
         """
 
@@ -1133,7 +1133,7 @@ class VaryingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribu
                                                       self.N)
 
     def plates_to_parent(self, index, plates):
-        """
+        r"""
         Computes the plates of this node with respect to a parent.
 
         If this node has plates (...), the latent dimensionality is D
@@ -1164,7 +1164,7 @@ class VaryingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistribu
             raise ValueError("Invalid parent index.")
 
     def plates_from_parent(self, index, plates):
-        """
+        r"""
         Compute the plates using information of a parent node.
 
         If the plates of the parents are:
@@ -1321,7 +1321,7 @@ class VaryingGaussianMarkovChain(_TemplateGaussianMarkovChain):
     """
 
     def __init__(self, mu, Lambda, B, S, nu, n=None, **kwargs):
-        """
+        r"""
         Create VaryingGaussianMarkovChain node.
         """
         super().__init__(mu, Lambda, B, S, nu, n=n, **kwargs)
@@ -1329,7 +1329,7 @@ class VaryingGaussianMarkovChain(_TemplateGaussianMarkovChain):
 
     @classmethod
     def _constructor(cls, mu, Lambda, B, S, v, n=None, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
 
         Compute the dimensions of phi and u.
@@ -1463,7 +1463,7 @@ class SwitchingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistri
 
     def compute_message_to_parent(self, parent, index, u, u_mu, u_Lambda, u_B,
                                    u_Z, u_v):
-        """
+        r"""
         Compute a message to a parent.
 
         Parameters
@@ -1582,7 +1582,7 @@ class SwitchingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistri
 
     def compute_phi_from_parents(self, u_mu, u_Lambda, u_B, u_Z, u_v,
                                  mask=True):
-        """
+        r"""
         Compute the natural parameters using parents' moments.
 
         Parameters
@@ -1664,7 +1664,7 @@ class SwitchingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistri
         return (phi0, phi1, phi2)
 
     def compute_cgf_from_parents(self, u_mu, u_Lambda, u_B, u_Z, u_v):
-        """
+        r"""
         Compute CGF using the moments of the parents.
         """
 
@@ -1675,7 +1675,7 @@ class SwitchingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistri
                                                       self.N)
 
     def plates_to_parent(self, index, plates):
-        """
+        r"""
         Computes the plates of this node with respect to a parent.
 
         If this node has plates (...), the latent dimensionality is D
@@ -1707,7 +1707,7 @@ class SwitchingGaussianMarkovChainDistribution(TemplateGaussianMarkovChainDistri
 
 
     def plates_from_parent(self, index, plates):
-        """
+        r"""
         Compute the plates using information of a parent node.
 
         If the plates of the parents are:
@@ -1856,7 +1856,7 @@ class SwitchingGaussianMarkovChain(_TemplateGaussianMarkovChain):
 
 
     def __init__(self, mu, Lambda, B, Z, nu, n=None, **kwargs):
-        """
+        r"""
         Create SwitchingGaussianMarkovChain node.
         """
         super().__init__(mu, Lambda, B, Z, nu, n=n, **kwargs)
@@ -1864,7 +1864,7 @@ class SwitchingGaussianMarkovChain(_TemplateGaussianMarkovChain):
 
     @classmethod
     def _constructor(cls, mu, Lambda, B, Z, v, n=None, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
 
         Compute the dimensions of phi and u.
@@ -2005,7 +2005,7 @@ class _MarkovChainToGaussian(Deterministic):
 
 
     def _plates_to_parent(self, index):
-        """
+        r"""
         Return the number of plates to the parent node.
 
         Normally, the parent sees the same number of plates as the
@@ -2033,7 +2033,7 @@ class _MarkovChainToGaussian(Deterministic):
         return plates
 
     def _compute_moments(self, u):
-        """
+        r"""
         Transform the moments of a GMC to moments of a Gaussian.
 
         There is no need to worry about the plates and variable
@@ -2059,7 +2059,7 @@ class _MarkovChainToGaussian(Deterministic):
 
     @staticmethod
     def _compute_message_to_parent(index, m_children, *u_parents):
-        """
+        r"""
         Transform a message to a Gaussian into a message to a GMC.
 
         The messages to a Gaussian are almost correct, there are only

--- a/bayespy/inference/vmp/nodes/logistic.py
+++ b/bayespy/inference/vmp/nodes/logistic.py
@@ -25,7 +25,7 @@ from bayespy.utils import misc
 
 
 class CategoricalDistribution(MultinomialDistribution):
-    """
+    r"""
     Class for the VMP formulas of categorical variables.
     """
 

--- a/bayespy/inference/vmp/nodes/logistic.py
+++ b/bayespy/inference/vmp/nodes/logistic.py
@@ -30,7 +30,7 @@ class CategoricalDistribution(MultinomialDistribution):
     """
 
     def __init__(self, categories):
-        """
+        r"""
         Create VMP formula node for a categorical variable
 
         `categories` is the total number of categories.
@@ -44,35 +44,35 @@ class CategoricalDistribution(MultinomialDistribution):
 
 
     def compute_message_to_parent(self, parent, index, u, u_p):
-        """
+        r"""
         Compute the message to a parent node.
         """
         return super().compute_message_to_parent(parent, index, u, u_p)
 
 
     def compute_phi_from_parents(self, u_p, mask=True):
-        """
+        r"""
         Compute the natural parameter vector given parent moments.
         """
         return super().compute_phi_from_parents(u_p, mask=mask)
 
 
     def compute_moments_and_cgf(self, phi, mask=True):
-        """
+        r"""
         Compute the moments and :math:`g(\phi)`.
         """
         return super().compute_moments_and_cgf(phi, mask=mask)
 
 
     def compute_cgf_from_parents(self, u_p):
-        """
+        r"""
         Compute :math:`\mathrm{E}_{q(p)}[g(p)]`
         """
         return super().compute_cgf_from_parents(u_p)
 
 
     def compute_fixed_moments_and_f(self, x, mask=True):
-        """
+        r"""
         Compute the moments and :math:`f(x)` for a fixed value.
         """
 
@@ -96,7 +96,7 @@ class CategoricalDistribution(MultinomialDistribution):
 
 
     def random(self, *phi, plates=None):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         logp = phi[0]
@@ -201,7 +201,7 @@ class Logistic(ExponentialFamily):
 
 
     def __init__(self, x, **kwargs):
-        """
+        r"""
         """
         super().__init__(x, **kwargs)
 
@@ -209,7 +209,7 @@ class Logistic(ExponentialFamily):
     @classmethod
     @ensureparents
     def _constructor(cls, x, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
         """
 
@@ -231,7 +231,7 @@ class Logistic(ExponentialFamily):
 
 
     def __str__(self):
-        """
+        r"""
         Print the distribution using standard parameterization.
         """
         raise NotImplementedError()

--- a/bayespy/inference/vmp/nodes/logpdf.py
+++ b/bayespy/inference/vmp/nodes/logpdf.py
@@ -17,7 +17,7 @@ class LogPDFDistribution(Distribution):
 
 
 class LogPDF(ExponentialFamily):
-    """
+    r"""
     General node with arbitrary probability density function
     """
 
@@ -101,4 +101,3 @@ class LogPDF(ExponentialFamily):
         # Observed nodes should not be ignored
         self.observed = mask
         self._update_mask()
-

--- a/bayespy/inference/vmp/nodes/logpdf.py
+++ b/bayespy/inference/vmp/nodes/logpdf.py
@@ -73,7 +73,7 @@ class LogPDF(ExponentialFamily):
 
 
     def observe(self, x, *args, mask=True):
-        """
+        r"""
         Fix moments, compute f and propagate mask.
         """
 

--- a/bayespy/inference/vmp/nodes/mixture.py
+++ b/bayespy/inference/vmp/nodes/mixture.py
@@ -24,7 +24,7 @@ from .categorical import Categorical, \
                          CategoricalMoments
 
 class MixtureDistribution(ExponentialFamilyDistribution):
-    """
+    r"""
     Class for the VMP formulas of mixture variables.
     """
 
@@ -546,7 +546,7 @@ class Mixture(ExponentialFamily):
 
 
 def MultiMixture(thetas, *mixture_args, **kwargs):
-    """Creates a mixture over several axes using as many categorical variables.
+    r"""Creates a mixture over several axes using as many categorical variables.
 
     The mixings are assumed to be separate, that is, inner mixings don't affect
     the parameters of outer mixings.

--- a/bayespy/inference/vmp/nodes/mixture.py
+++ b/bayespy/inference/vmp/nodes/mixture.py
@@ -490,7 +490,7 @@ class Mixture(ExponentialFamily):
 
     def integrated_logpdf_from_parents(self, x, index):
 
-        """ Approximates the posterior predictive pdf \int p(x|parents)
+        r""" Approximates the posterior predictive pdf \int p(x|parents)
         q(parents) dparents in log-scale as \int q(parents_i) exp( \int
         q(parents_\i) \log p(x|parents) dparents_\i ) dparents_i."""
 

--- a/bayespy/inference/vmp/nodes/mixture.py
+++ b/bayespy/inference/vmp/nodes/mixture.py
@@ -31,7 +31,7 @@ class MixtureDistribution(ExponentialFamilyDistribution):
 
     def __init__(self, distribution, cluster_plate, n_clusters, ndims,
                  ndims_parents):
-        """
+        r"""
         Create VMP formula node for a mixture variable
         """
         self.raw_distribution = distribution
@@ -51,7 +51,7 @@ class MixtureDistribution(ExponentialFamilyDistribution):
 
 
     def compute_message_to_parent(self, parent, index, u, *u_parents):
-        """
+        r"""
         Compute the message to a parent node.
         """
 
@@ -161,7 +161,7 @@ class MixtureDistribution(ExponentialFamilyDistribution):
 
 
     def compute_weights_to_parent(self, index, weights):
-        """
+        r"""
         Maps the mask to the plates of a parent.
         """
         if index == 0:
@@ -178,7 +178,7 @@ class MixtureDistribution(ExponentialFamilyDistribution):
 
 
     def compute_phi_from_parents(self, *u_parents, mask=True):
-        """
+        r"""
         Compute the natural parameter vector given parent moments.
         """
         # Compute weighted average of the parameters
@@ -249,14 +249,14 @@ class MixtureDistribution(ExponentialFamilyDistribution):
 
 
     def compute_moments_and_cgf(self, phi, mask=True):
-        """
+        r"""
         Compute the moments and :math:`g(\phi)`.
         """
         return self.squeezed_distribution.compute_moments_and_cgf(phi, mask=mask)
 
 
     def compute_cgf_from_parents(self, *u_parents):
-        """
+        r"""
         Compute :math:`\mathrm{E}_{q(p)}[g(p)]`
         """
 
@@ -294,14 +294,14 @@ class MixtureDistribution(ExponentialFamilyDistribution):
 
 
     def compute_fixed_moments_and_f(self, x, mask=True):
-        """
+        r"""
         Compute the moments and :math:`f(x)` for a fixed value.
         """
         return self.squeezed_distribution.compute_fixed_moments_and_f(x, mask=True)
 
 
     def plates_to_parent(self, index, plates):
-        """
+        r"""
         Resolves the plate mapping to a parent.
 
         Given the plates of the node's moments, this method returns the plates
@@ -324,7 +324,7 @@ class MixtureDistribution(ExponentialFamilyDistribution):
 
 
     def plates_from_parent(self, index, plates):
-        """
+        r"""
         Resolve the plate mapping from a parent.
 
         Given the plates of a parent's moments, this method returns the plates
@@ -343,7 +343,7 @@ class MixtureDistribution(ExponentialFamilyDistribution):
 
 
     def random(self, *phi, plates=None):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         return self.squeezed_distribution.random(*phi, plates=plates)
@@ -434,7 +434,7 @@ class Mixture(ExponentialFamily):
 
     @classmethod
     def _constructor(cls, z, node_class, *args, cluster_plate=-1, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
         """
         if cluster_plate >= 0:

--- a/bayespy/inference/vmp/nodes/multinomial.py
+++ b/bayespy/inference/vmp/nodes/multinomial.py
@@ -24,7 +24,7 @@ from bayespy.utils import linalg
 
 
 class MultinomialMoments(Moments):
-    """
+    r"""
     Class for the moments of multinomial variables.
     """
 
@@ -60,7 +60,7 @@ class MultinomialMoments(Moments):
 
 
 class MultinomialDistribution(ExponentialFamilyDistribution):
-    """
+    r"""
     Class for the VMP formulas of multinomial variables.
     """
 

--- a/bayespy/inference/vmp/nodes/multinomial.py
+++ b/bayespy/inference/vmp/nodes/multinomial.py
@@ -35,7 +35,7 @@ class MultinomialMoments(Moments):
 
 
     def compute_fixed_moments(self, x):
-        """
+        r"""
         Compute the moments for a fixed value
 
         `x` must be a vector of counts.
@@ -66,7 +66,7 @@ class MultinomialDistribution(ExponentialFamilyDistribution):
 
 
     def __init__(self, trials):
-        """
+        r"""
         Create VMP formula node for a multinomial variable
 
         `trials` is the total number of trials.
@@ -81,7 +81,7 @@ class MultinomialDistribution(ExponentialFamilyDistribution):
 
 
     def compute_message_to_parent(self, parent, index, u, u_p):
-        """
+        r"""
         Compute the message to a parent node.
         """
         if index == 0:
@@ -91,7 +91,7 @@ class MultinomialDistribution(ExponentialFamilyDistribution):
 
 
     def compute_phi_from_parents(self, u_p, mask=True):
-        """
+        r"""
         Compute the natural parameter vector given parent moments.
         """
         logp = u_p[0]
@@ -266,7 +266,7 @@ class Multinomial(ExponentialFamily):
 
 
     def __init__(self, n, p, **kwargs):
-        """
+        r"""
         Create Multinomial node.
         """
         super().__init__(n, p, **kwargs)
@@ -274,7 +274,7 @@ class Multinomial(ExponentialFamily):
 
     @classmethod
     def _constructor(cls, n, p, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
 
         This method is called if useconstructor decorator is used for __init__.
@@ -307,7 +307,7 @@ class Multinomial(ExponentialFamily):
 
 
     def __str__(self):
-        """
+        r"""
         Print the distribution using standard parameterization.
         """
         logsum_p = misc.logsumexp(self.phi[0], axis=-1, keepdims=True)

--- a/bayespy/inference/vmp/nodes/node.py
+++ b/bayespy/inference/vmp/nodes/node.py
@@ -15,7 +15,7 @@ This module contains a sketch of a new implementation of the framework.
 """
 
 def message_sum_multiply(plates_parent, dims_parent, *arrays):
-    """
+    r"""
     Compute message to parent and sum over plates.
 
     Divide by the plate multiplier.
@@ -48,7 +48,7 @@ def message_sum_multiply(plates_parent, dims_parent, *arrays):
 
 
 class Moments():
-    """
+    r"""
     Base class for defining the expectation of the sufficient statistics.
 
     The benefits:
@@ -221,7 +221,7 @@ def ensureparents(func):
 
 
 class Node():
-    """
+    r"""
     Base class for all nodes.
 
     mask

--- a/bayespy/inference/vmp/nodes/node.py
+++ b/bayespy/inference/vmp/nodes/node.py
@@ -78,7 +78,7 @@ class Moments():
 
 
     def get_instance_converter(self, **kwargs):
-        """Default converter within a moments class is an identity.
+        r"""Default converter within a moments class is an identity.
 
         Override this method when moment class instances are not identical if
         they have different attributes.
@@ -93,7 +93,7 @@ class Moments():
 
 
     def get_instance_conversion_kwargs(self):
-        """
+        r"""
         Override this method when moment class instances are not identical if
         they have different attributes.
         """
@@ -108,7 +108,7 @@ class Moments():
 
 
     def get_converter(self, moments_to):
-        """
+        r"""
         Finds conversion to another moments type if possible.
 
         Note that a conversion from moments A to moments B may require
@@ -314,7 +314,7 @@ class Node():
 
 
     def _get_id_list(self):
-        """
+        r"""
         Returns the stochastic ID list.
 
         This method is used to check that same stochastic nodes are not direct
@@ -409,7 +409,7 @@ class Node():
 
     @property
     def plates_multiplier(self):
-        """ Plate multiplier is applied to messages to parents """
+        r""" Plate multiplier is applied to messages to parents """
         return self.__plates_multiplier
 
 
@@ -424,7 +424,7 @@ class Node():
         return self.plates + self.dims[ind]
 
     def _add_child(self, child, index):
-        """
+        r"""
         Add a child node.
 
         Parameters
@@ -438,7 +438,7 @@ class Node():
         self.children.add((child, index))
 
     def _remove_child(self, child, index):
-        """
+        r"""
         Remove a child node.
         """
         self.children.remove((child, index))
@@ -476,7 +476,7 @@ class Node():
 
 
     def _compute_weights_to_parent(self, index, weights):
-        """Compute the mask used for messages sent to parent[index].
+        r"""Compute the mask used for messages sent to parent[index].
 
         The mask tells which plates in the messages are active. This method is
         used for obtaining the mask which is used to set plates in the messages
@@ -490,7 +490,7 @@ class Node():
 
 
     def _mask_to_parent(self, index):
-        """
+        r"""
         Get the mask with respect to parent[index].
 
         The mask tells which plate connections are active. The mask is "summed"
@@ -697,7 +697,7 @@ class Node():
         raise NotImplementedError()
 
     def delete(self):
-        """
+        r"""
         Delete this node and the children
         """
         for (ind, parent) in enumerate(self.parents):
@@ -763,7 +763,7 @@ class Node():
                      name=(self.name+".__getitem__"))
 
     def has_plotter(self):
-        """
+        r"""
         Return True if the node has a plotter
         """
         return callable(self._plotter)
@@ -772,7 +772,7 @@ class Node():
         self._plotter = plotter
 
     def plot(self, fig=None, **kwargs):
-        """
+        r"""
         Plot the node distribution using the plotter of the node
 
         Because the distributions are in general very difficult to plot, the
@@ -793,7 +793,7 @@ class Node():
 
     @staticmethod
     def _compute_message(*arrays, plates_from=(), plates_to=(), ndim=0):
-        """
+        r"""
         A general function for computing messages by sum-multiply
 
         The function computes the product of the input arrays and then sums to
@@ -1019,7 +1019,7 @@ class Slice(Deterministic):
 
     @staticmethod
     def __reverse_indexing(slices, m_child, plates, dims):
-        """
+        r"""
         A helpful function for performing reverse indexing/slicing
         """
 
@@ -1082,7 +1082,7 @@ class Slice(Deterministic):
 
 
     def _compute_weights_to_parent(self, index, weights):
-        """
+        r"""
         Compute the mask to the parent node.
         """
         if index != 0:
@@ -1096,7 +1096,7 @@ class Slice(Deterministic):
 
 
     def _compute_message_to_parent(self, index, m, u):
-        """
+        r"""
         Compute the message to a parent node.
         """
 
@@ -1114,7 +1114,7 @@ class Slice(Deterministic):
         return msg
 
     def _compute_moments(self, u):
-        """
+        r"""
         Get the moments with an added plate axis.
         """
 
@@ -1222,7 +1222,7 @@ def AddPlateAxis(to_plate):
 
 
         def _compute_message_to_parent(self, index, m, *u_parents):
-            """
+            r"""
             Compute the message to a parent node.
             """
 
@@ -1238,7 +1238,7 @@ def AddPlateAxis(to_plate):
             return m
 
         def _compute_moments(self, u):
-            """
+            r"""
             Get the moments with an added plate axis.
             """
 
@@ -1268,7 +1268,7 @@ def AddPlateAxis(to_plate):
 class NodeConstantScalar(Node):
     @staticmethod
     def compute_fixed_u_and_f(x):
-        """ Compute u(x) and f(x) for given x. """
+        r""" Compute u(x) and f(x) for given x. """
         return ([x], 0)
 
     def __init__(self, a, **kwargs):

--- a/bayespy/inference/vmp/nodes/point_estimate.py
+++ b/bayespy/inference/vmp/nodes/point_estimate.py
@@ -161,7 +161,7 @@ class Constant(Node):
 
 
     def _get_id_list(self):
-        """
+        r"""
         Returns the stochastic ID list.
 
         This method is used to check that same stochastic nodes are not direct

--- a/bayespy/inference/vmp/nodes/poisson.py
+++ b/bayespy/inference/vmp/nodes/poisson.py
@@ -22,7 +22,7 @@ from bayespy.utils import misc
 
 
 class PoissonMoments(Moments):
-    """
+    r"""
     Class for the moments of Poisson variables
     """
 
@@ -53,7 +53,7 @@ class PoissonMoments(Moments):
 
 
 class PoissonDistribution(ExponentialFamilyDistribution):
-    """
+    r"""
     Class for the VMP formulas of Poisson variables.
     """
 
@@ -129,7 +129,7 @@ class PoissonDistribution(ExponentialFamilyDistribution):
 
 
 class Poisson(ExponentialFamily):
-    """
+    r"""
     Node for Poisson random variables.
 
     The node uses Poisson distribution:

--- a/bayespy/inference/vmp/nodes/poisson.py
+++ b/bayespy/inference/vmp/nodes/poisson.py
@@ -31,7 +31,7 @@ class PoissonMoments(Moments):
 
 
     def compute_fixed_moments(self, x):
-        """
+        r"""
         Compute the moments for a fixed value
         """
         # Make sure the values are integers in valid range
@@ -44,7 +44,7 @@ class PoissonMoments(Moments):
 
     @classmethod
     def from_values(cls, x):
-        """
+        r"""
         Return the shape of the moments for a fixed value.
 
         The realizations are scalars, thus the shape of the moment is ().
@@ -59,7 +59,7 @@ class PoissonDistribution(ExponentialFamilyDistribution):
 
 
     def compute_message_to_parent(self, parent, index, u, u_lambda):
-        """
+        r"""
         Compute the message to a parent node.
         """
         if index == 0:
@@ -71,7 +71,7 @@ class PoissonDistribution(ExponentialFamilyDistribution):
 
 
     def compute_phi_from_parents(self, u_lambda, mask=True):
-        """
+        r"""
         Compute the natural parameter vector given parent moments.
         """
         l = u_lambda[0]
@@ -81,7 +81,7 @@ class PoissonDistribution(ExponentialFamilyDistribution):
 
 
     def compute_moments_and_cgf(self, phi, mask=True):
-        """
+        r"""
         Compute the moments and :math:`g(\phi)`.
         """
         u0 = np.exp(phi[0])
@@ -91,7 +91,7 @@ class PoissonDistribution(ExponentialFamilyDistribution):
 
         
     def compute_cgf_from_parents(self, u_lambda):
-        """
+        r"""
         Compute :math:`\mathrm{E}_{q(p)}[g(p)]`
         """
         l = u_lambda[0]
@@ -100,7 +100,7 @@ class PoissonDistribution(ExponentialFamilyDistribution):
     
 
     def compute_fixed_moments_and_f(self, x, mask=True):
-        """
+        r"""
         Compute the moments and :math:`f(x)` for a fixed value.
         """
 
@@ -122,7 +122,7 @@ class PoissonDistribution(ExponentialFamilyDistribution):
 
 
     def random(self, *phi, plates=None):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         return np.random.poisson(np.exp(phi[0]), size=plates)
@@ -160,14 +160,14 @@ class Poisson(ExponentialFamily):
 
 
     def __init__(self, l, **kwargs):
-        """
+        r"""
         Create Poisson random variable node
         """
         super().__init__(l, **kwargs)
 
         
     def __str__(self):
-        """
+        r"""
         Print the distribution using standard parameterization.
         """
         l = self.u[0]

--- a/bayespy/inference/vmp/nodes/stochastic.py
+++ b/bayespy/inference/vmp/nodes/stochastic.py
@@ -14,7 +14,7 @@ import h5py
 from .node import Node
 
 class Distribution():
-    """
+    r"""
     A base class for the VMP formulas of variables.
 
     Sub-classes implement distribution specific computations.
@@ -81,7 +81,7 @@ class Distribution():
 
 
 class Stochastic(Node):
-    """
+    r"""
     Base class for nodes that are stochastic.
 
     u

--- a/bayespy/inference/vmp/nodes/stochastic.py
+++ b/bayespy/inference/vmp/nodes/stochastic.py
@@ -31,14 +31,14 @@ class Distribution():
 
 
     def compute_message_to_parent(self, parent, index, u_self, *u_parents):
-        """
+        r"""
         Compute the message to a parent node.
         """
         raise NotImplementedError()
 
 
     def compute_weights_to_parent(self, index, weights):
-        """
+        r"""
         Maps the mask to the plates of a parent.
         """
         # Sub-classes may need to overwrite this method
@@ -46,7 +46,7 @@ class Distribution():
 
 
     def plates_to_parent(self, index, plates):
-        """
+        r"""
         Resolves the plate mapping to a parent.
 
         Given the plates of the node's moments, this method returns the plates
@@ -55,7 +55,7 @@ class Distribution():
         return plates
 
     def plates_from_parent(self, index, plates):
-        """
+        r"""
         Resolve the plate mapping from a parent.
 
         Given the plates of a parent's moments, this method returns the plates
@@ -65,13 +65,13 @@ class Distribution():
 
 
     def random(self, *params, plates=None):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         raise NotImplementedError()
 
     def squeeze(self, axis):
-        """Squeeze a plate axis from the distribution
+        r"""Squeeze a plate axis from the distribution
 
         The default implementation does no changes to the distribution.
         Override if needed.
@@ -140,7 +140,7 @@ class Stochastic(Node):
 
 
     def _get_id_list(self):
-        """
+        r"""
         Returns the stochastic ID list.
 
         This method is used to check that same stochastic nodes are not direct
@@ -283,7 +283,7 @@ class Stochastic(Node):
 
 
     def observe(self, x, mask=True):
-        """
+        r"""
         Fix moments, compute f and propagate mask.
         """
         raise NotImplementedError()
@@ -318,7 +318,7 @@ class Stochastic(Node):
 
 
     def _save(self, group):
-        """
+        r"""
         Save the state of the node into a HDF5 file.
 
         group can be the root
@@ -339,7 +339,7 @@ class Stochastic(Node):
 
 
     def _load(self, group):
-        """
+        r"""
         Load the state of the node from a HDF5 file.
         """
         # TODO/FIXME: Check that the shapes are correct!
@@ -355,21 +355,21 @@ class Stochastic(Node):
 
 
     def random(self):
-        """
+        r"""
         Draw a random sample from the distribution.
         """
         raise NotImplementedError()
 
 
     def show(self):
-        """
+        r"""
         Print the distribution using standard parameterization.
         """
         print(str(self))
 
 
     def __str__(self):
-        """
+        r"""
 
         """
         raise NotImplementedError("String representation not yet implemented for "

--- a/bayespy/inference/vmp/nodes/take.py
+++ b/bayespy/inference/vmp/nodes/take.py
@@ -12,7 +12,7 @@ from bayespy.utils import misc
 
 
 class Take(Deterministic):
-    """
+    r"""
     Choose elements/sub-arrays along a plate axis
 
     Basically, applies `np.take` on a plate axis. Allows advanced mapping of

--- a/bayespy/inference/vmp/nodes/tests/test_bernoulli.py
+++ b/bayespy/inference/vmp/nodes/tests/test_bernoulli.py
@@ -22,7 +22,7 @@ from bayespy.utils.misc import TestCase
 
 
 class TestBernoulli(TestCase):
-    """
+    r"""
     Unit tests for Bernoulli node
     """
 

--- a/bayespy/inference/vmp/nodes/tests/test_bernoulli.py
+++ b/bayespy/inference/vmp/nodes/tests/test_bernoulli.py
@@ -28,7 +28,7 @@ class TestBernoulli(TestCase):
 
     
     def test_init(self):
-        """
+        r"""
         Test the creation of Bernoulli nodes.
         """
 
@@ -71,7 +71,7 @@ class TestBernoulli(TestCase):
 
     
     def test_moments(self):
-        """
+        r"""
         Test the moments of Bernoulli nodes.
         """
 
@@ -109,7 +109,7 @@ class TestBernoulli(TestCase):
 
 
     def test_mixture(self):
-        """
+        r"""
         Test mixture of Bernoulli
         """
         P = Mixture([2,0,0], Bernoulli, [0.1, 0.2, 0.3])
@@ -120,7 +120,7 @@ class TestBernoulli(TestCase):
 
 
     def test_observed(self):
-        """
+        r"""
         Test observation of Bernoulli node
         """
         Z = Bernoulli(0.3)
@@ -129,7 +129,7 @@ class TestBernoulli(TestCase):
 
 
     def test_random(self):
-        """
+        r"""
         Test random sampling in Bernoulli node
         """
         p = [1.0, 0.0]

--- a/bayespy/inference/vmp/nodes/tests/test_beta.py
+++ b/bayespy/inference/vmp/nodes/tests/test_beta.py
@@ -19,7 +19,7 @@ from bayespy.utils import random
 from bayespy.utils.misc import TestCase
 
 class TestBeta(TestCase):
-    """
+    r"""
     Unit tests for Beta node
     """
 

--- a/bayespy/inference/vmp/nodes/tests/test_beta.py
+++ b/bayespy/inference/vmp/nodes/tests/test_beta.py
@@ -25,7 +25,7 @@ class TestBeta(TestCase):
 
     
     def test_init(self):
-        """
+        r"""
         Test the creation of beta nodes.
         """
 
@@ -74,7 +74,7 @@ class TestBeta(TestCase):
 
     
     def test_moments(self):
-        """
+        r"""
         Test the moments of beta nodes.
         """
 
@@ -87,7 +87,7 @@ class TestBeta(TestCase):
 
     
     def test_random(self):
-        """
+        r"""
         Test random sampling of beta nodes.
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_binomial.py
+++ b/bayespy/inference/vmp/nodes/tests/test_binomial.py
@@ -22,7 +22,7 @@ from bayespy.utils.misc import TestCase
 
 
 class TestBinomial(TestCase):
-    """
+    r"""
     Unit tests for Binomial node
     """
 

--- a/bayespy/inference/vmp/nodes/tests/test_binomial.py
+++ b/bayespy/inference/vmp/nodes/tests/test_binomial.py
@@ -28,7 +28,7 @@ class TestBinomial(TestCase):
 
 
     def test_init(self):
-        """
+        r"""
         Test the creation of binomial nodes.
         """
 
@@ -89,7 +89,7 @@ class TestBinomial(TestCase):
 
 
     def test_moments(self):
-        """
+        r"""
         Test the moments of binomial nodes.
         """
 
@@ -150,7 +150,7 @@ class TestBinomial(TestCase):
 
 
     def test_mixture(self):
-        """
+        r"""
         Test binomial mixture
         """
 
@@ -163,7 +163,7 @@ class TestBinomial(TestCase):
 
 
     def test_observed(self):
-        """
+        r"""
         Test observation of Bernoulli node
         """
         Z = Binomial(10, 0.3)
@@ -180,7 +180,7 @@ class TestBinomial(TestCase):
         pass
 
     def test_random(self):
-        """
+        r"""
         Test random sampling in Binomial node
         """
         N = [ [5], [50] ]
@@ -190,7 +190,7 @@ class TestBinomial(TestCase):
         self.assertArrayEqual(Z, np.ones((3,2,2))*N*p)
 
     def test_mixture_with_count_array(self):
-        """
+        r"""
         Test binomial mixture with varying number of trials
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_categorical.py
+++ b/bayespy/inference/vmp/nodes/tests/test_categorical.py
@@ -26,7 +26,7 @@ from bayespy.utils.misc import TestCase
 
 
 class TestCategorical(TestCase):
-    """
+    r"""
     Unit tests for Categorical node
     """
 

--- a/bayespy/inference/vmp/nodes/tests/test_categorical.py
+++ b/bayespy/inference/vmp/nodes/tests/test_categorical.py
@@ -32,7 +32,7 @@ class TestCategorical(TestCase):
 
     
     def test_init(self):
-        """
+        r"""
         Test the creation of categorical nodes.
         """
 
@@ -85,7 +85,7 @@ class TestCategorical(TestCase):
 
     
     def test_moments(self):
-        """
+        r"""
         Test the moments of categorical nodes.
         """
 
@@ -125,7 +125,7 @@ class TestCategorical(TestCase):
 
 
     def test_observed(self):
-        """
+        r"""
         Test observed categorical nodes
         """
 
@@ -173,7 +173,7 @@ class TestCategorical(TestCase):
 
     
     def test_constant(self):
-        """
+        r"""
         Test constant categorical nodes
         """
 
@@ -206,7 +206,7 @@ class TestCategorical(TestCase):
 
 
     def test_initialization(self):
-        """
+        r"""
         Test initialization of categorical nodes
         """
 
@@ -226,7 +226,7 @@ class TestCategorical(TestCase):
 
 
     def test_gradient(self):
-        """
+        r"""
         Check the Euclidean gradient of the categorical node
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_categorical_markov_chain.py
+++ b/bayespy/inference/vmp/nodes/tests/test_categorical_markov_chain.py
@@ -21,7 +21,7 @@ from bayespy.inference.vmp.nodes import CategoricalMarkovChain, \
 class TestCategoricalMarkovChain(misc.TestCase):
 
     def test_init(self):
-        """
+        r"""
         Test the creation of CategoricalMarkovChain object
         """
 
@@ -62,7 +62,7 @@ class TestCategoricalMarkovChain(misc.TestCase):
         pass
     
     def test_message_to_child(self):
-        """
+        r"""
         Test the message of CategoricalMarkovChain to child
         """
 
@@ -156,7 +156,7 @@ class TestCategoricalMarkovChain(misc.TestCase):
 
 
     def test_random(self):
-        """
+        r"""
         Test random sampling of categorical Markov chain
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_concatenate.py
+++ b/bayespy/inference/vmp/nodes/tests/test_concatenate.py
@@ -23,7 +23,7 @@ from bayespy.utils.misc import TestCase
 
 
 class TestConcatenate(TestCase):
-    """
+    r"""
     Unit tests for Concatenate node.
     """
     

--- a/bayespy/inference/vmp/nodes/tests/test_concatenate.py
+++ b/bayespy/inference/vmp/nodes/tests/test_concatenate.py
@@ -29,7 +29,7 @@ class TestConcatenate(TestCase):
     
 
     def test_init(self):
-        """
+        r"""
         Test the creation of Concatenate node
         """
 
@@ -108,7 +108,7 @@ class TestConcatenate(TestCase):
         
 
     def test_message_to_child(self):
-        """
+        r"""
         Test the message to child of Concatenate node.
         """
 
@@ -188,7 +188,7 @@ class TestConcatenate(TestCase):
 
 
     def test_message_to_parent(self):
-        """
+        r"""
         Test the message to parents of Concatenate node.
         """
 
@@ -271,7 +271,7 @@ class TestConcatenate(TestCase):
 
 
     def test_mask_to_parent(self):
-        """
+        r"""
         Test the mask handling in Concatenate node
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_deterministic.py
+++ b/bayespy/inference/vmp/nodes/tests/test_deterministic.py
@@ -46,7 +46,7 @@ class TestTile(unittest.TestCase):
 
 
     def test_message_to_children(self):
-        """
+        r"""
         Test the moments of Tile node.
         """
         # Define th check function
@@ -157,7 +157,7 @@ class TestTile(unittest.TestCase):
 
 
     def test_message_to_parent(self):
-        """
+        r"""
         Test the parent message of Tile node.
         """
         # Define th check function
@@ -271,7 +271,7 @@ class TestTile(unittest.TestCase):
 
 
     def test_mask_to_parent(self):
-        """
+        r"""
         Test the mask message to parent of Tile node.
         """
         # Define th check function

--- a/bayespy/inference/vmp/nodes/tests/test_dirichlet.py
+++ b/bayespy/inference/vmp/nodes/tests/test_dirichlet.py
@@ -19,7 +19,7 @@ from bayespy.utils import random
 from bayespy.utils.misc import TestCase
 
 class TestDirichlet(TestCase):
-    """
+    r"""
     Unit tests for Dirichlet node
     """
 

--- a/bayespy/inference/vmp/nodes/tests/test_dirichlet.py
+++ b/bayespy/inference/vmp/nodes/tests/test_dirichlet.py
@@ -25,7 +25,7 @@ class TestDirichlet(TestCase):
 
     
     def test_init(self):
-        """
+        r"""
         Test the creation of Dirichlet nodes.
         """
 
@@ -66,7 +66,7 @@ class TestDirichlet(TestCase):
 
     
     def test_moments(self):
-        """
+        r"""
         Test the moments of Dirichlet nodes.
         """
 
@@ -79,7 +79,7 @@ class TestDirichlet(TestCase):
 
 
     def test_constant(self):
-        """
+        r"""
         Test the constant moments of Dirichlet nodes.
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_dot.py
+++ b/bayespy/inference/vmp/nodes/tests/test_dot.py
@@ -1013,7 +1013,7 @@ class TestSumMultiply(TestCase):
 
 
 def check_performance(scale=1e2):
-    """
+    r"""
     Tests that the implementation of SumMultiply is efficient.
 
     This is not a unit test (not run automatically), but rather a

--- a/bayespy/inference/vmp/nodes/tests/test_dot.py
+++ b/bayespy/inference/vmp/nodes/tests/test_dot.py
@@ -32,7 +32,7 @@ from bayespy.utils.misc import TestCase
 class TestSumMultiply(TestCase):
 
     def test_parent_validity(self):
-        """
+        r"""
         Test that the parent nodes are validated properly in SumMultiply
         """
         V = GaussianARD(1, 1)
@@ -157,7 +157,7 @@ class TestSumMultiply(TestCase):
 
 
     def test_message_to_child(self):
-        """
+        r"""
         Test the message from SumMultiply to its children.
         """
 
@@ -499,7 +499,7 @@ class TestSumMultiply(TestCase):
 
 
     def test_message_to_parent(self):
-        """
+        r"""
         Test the message from SumMultiply node to its parents.
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_gamma.py
+++ b/bayespy/inference/vmp/nodes/tests/test_gamma.py
@@ -89,7 +89,7 @@ class TestGamma(TestCase):
 
 
 class TestGammaGradient(TestCase):
-    """Numerically check Riemannian gradient of several nodes.
+    r"""Numerically check Riemannian gradient of several nodes.
 
     Using VB-EM update equations will take a unit length step to the
     Riemannian gradient direction.  Thus, the change caused by a VB-EM

--- a/bayespy/inference/vmp/nodes/tests/test_gamma.py
+++ b/bayespy/inference/vmp/nodes/tests/test_gamma.py
@@ -97,7 +97,7 @@ class TestGammaGradient(TestCase):
     """
 
     def test_riemannian_gradient(self):
-        """Test Riemannian gradient of a Gamma node."""
+        r"""Test Riemannian gradient of a Gamma node."""
 
         #
         # Without observations
@@ -155,7 +155,7 @@ class TestGammaGradient(TestCase):
 
 
     def test_gradient(self):
-        """Test standard gradient of a Gamma node."""
+        r"""Test standard gradient of a Gamma node."""
         D = 3
 
         np.random.seed(42)

--- a/bayespy/inference/vmp/nodes/tests/test_gate.py
+++ b/bayespy/inference/vmp/nodes/tests/test_gate.py
@@ -27,7 +27,7 @@ from bayespy.utils.misc import TestCase
 
 
 class TestGate(TestCase):
-    """
+    r"""
     Unit tests for Gate node.
     """
 

--- a/bayespy/inference/vmp/nodes/tests/test_gate.py
+++ b/bayespy/inference/vmp/nodes/tests/test_gate.py
@@ -33,7 +33,7 @@ class TestGate(TestCase):
 
 
     def test_init(self):
-        """
+        r"""
         Test the creation of Gate node
         """
 
@@ -122,7 +122,7 @@ class TestGate(TestCase):
 
 
     def test_message_to_child(self):
-        """
+        r"""
         Test the message to child of Gate node.
         """
 
@@ -201,7 +201,7 @@ class TestGate(TestCase):
 
 
     def test_message_to_parent(self):
-        """
+        r"""
         Test the message to parents of Gate node.
         """
 
@@ -326,7 +326,7 @@ class TestGate(TestCase):
 
 
     def test_mask_to_parent(self):
-        """
+        r"""
         Test the mask handling in Gate node
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_gaussian.py
+++ b/bayespy/inference/vmp/nodes/tests/test_gaussian.py
@@ -919,7 +919,7 @@ class TestGaussianARD(TestCase):
 
 
 class TestGaussianGamma(TestCase):
-    """
+    r"""
     Unit tests for GaussianGamma node.
     """
 
@@ -1179,7 +1179,7 @@ class TestGaussian(TestCase):
 
 
 class TestGaussianGradient(TestCase):
-    """Numerically check Riemannian gradient of several nodes.
+    r"""Numerically check Riemannian gradient of several nodes.
 
     Using VB-EM update equations will take a unit length step to the
     Riemannian gradient direction.  Thus, the change caused by a VB-EM

--- a/bayespy/inference/vmp/nodes/tests/test_gaussian.py
+++ b/bayespy/inference/vmp/nodes/tests/test_gaussian.py
@@ -35,7 +35,7 @@ from bayespy.utils.misc import TestCase
 class TestGaussianFunctions(TestCase):
 
     def test_rotate_covariance(self):
-        """
+        r"""
         Test the Gaussian array covariance rotation.
         """
         # Check matrix
@@ -128,7 +128,7 @@ class TestGaussianFunctions(TestCase):
 class TestGaussianARD(TestCase):
 
     def test_init(self):
-        """
+        r"""
         Test the constructor of GaussianARD
         """
 
@@ -297,7 +297,7 @@ class TestGaussianARD(TestCase):
         pass
 
     def test_message_to_child(self):
-        """
+        r"""
         Test moments of GaussianARD.
         """
 
@@ -387,7 +387,7 @@ class TestGaussianARD(TestCase):
         pass
 
     def test_message_to_parent_mu(self):
-        """
+        r"""
         Test that GaussianARD computes the message to the 1st parent correctly.
         """
 
@@ -550,7 +550,7 @@ class TestGaussianARD(TestCase):
         pass
 
     def test_message_to_parent_alpha(self):
-        """
+        r"""
         Test the message from GaussianARD the 2nd parent (alpha).
         """
 
@@ -674,7 +674,7 @@ class TestGaussianARD(TestCase):
 
 
     def test_message_to_parents(self):
-        """ Check gradient passed to inputs parent node """
+        r""" Check gradient passed to inputs parent node """
         D = 3
 
         X = Gaussian(np.random.randn(D), random.covariance(D))
@@ -690,7 +690,7 @@ class TestGaussianARD(TestCase):
 
 
     def test_lowerbound(self):
-        """
+        r"""
         Test the variational Bayesian lower bound term for GaussianARD.
         """
 
@@ -779,7 +779,7 @@ class TestGaussianARD(TestCase):
         pass
 
     def test_rotate(self):
-        """
+        r"""
         Test the rotation of Gaussian ARD arrays.
         """
 
@@ -879,7 +879,7 @@ class TestGaussianARD(TestCase):
 
 
     def test_initialization(self):
-        """
+        r"""
         Test initialization methods of GaussianARD
         """
 
@@ -925,7 +925,7 @@ class TestGaussianGamma(TestCase):
 
 
     def test_init(self):
-        """
+        r"""
         Test the creation of GaussianGamma node
         """
 
@@ -998,7 +998,7 @@ class TestGaussianGamma(TestCase):
 
 
     def test_message_to_child(self):
-        """
+        r"""
         Test the message to child of GaussianGamma node.
         """
 
@@ -1073,7 +1073,7 @@ class TestGaussianGamma(TestCase):
 
 
     def test_mask_to_parent(self):
-        """
+        r"""
         Test the mask handling in GaussianGamma node
         """
 
@@ -1154,7 +1154,7 @@ class TestGaussian(TestCase):
 
 
     def test_message_to_parents(self):
-        """ Check gradient passed to inputs parent node """
+        r""" Check gradient passed to inputs parent node """
         D = 3
 
         X = Gaussian(np.random.randn(D), random.covariance(D))
@@ -1188,7 +1188,7 @@ class TestGaussianGradient(TestCase):
 
 
     def test_riemannian_gradient(self):
-        """Test Riemannian gradient of a Gaussian node."""
+        r"""Test Riemannian gradient of a Gaussian node."""
         D = 3
 
         #
@@ -1251,7 +1251,7 @@ class TestGaussianGradient(TestCase):
 
 
     def test_gradient(self):
-        """Test standard gradient of a Gaussian node."""
+        r"""Test standard gradient of a Gaussian node."""
         D = 3
 
         np.random.seed(42)

--- a/bayespy/inference/vmp/nodes/tests/test_gaussian_markov_chain.py
+++ b/bayespy/inference/vmp/nodes/tests/test_gaussian_markov_chain.py
@@ -27,7 +27,7 @@ from bayespy.utils.misc import TestCase
 
 
 def kalman_filter(y, U, A, V, mu0, Cov0, out=None):
-    """
+    r"""
     Perform Kalman filtering to obtain filtered mean and covariance.
 
     The parameters of the process may vary in time, thus they are
@@ -96,7 +96,7 @@ def kalman_filter(y, U, A, V, mu0, Cov0, out=None):
 
 
 def rts_smoother(mu, Cov, A, V, removethis=None):
-    """
+    r"""
     Perform Rauch-Tung-Striebel smoothing to obtain the posterior.
 
     The function returns the posterior mean and covariance of each

--- a/bayespy/inference/vmp/nodes/tests/test_gaussian_markov_chain.py
+++ b/bayespy/inference/vmp/nodes/tests/test_gaussian_markov_chain.py
@@ -181,7 +181,7 @@ class TestGaussianMarkovChain(TestCase):
 
 
     def test_plates(self):
-        """
+        r"""
         Test that plates are handled correctly.
         """
 
@@ -199,7 +199,7 @@ class TestGaussianMarkovChain(TestCase):
 
 
     def test_message_to_parents(self):
-        """ Check gradient passed to inputs parent node """
+        r""" Check gradient passed to inputs parent node """
         N = 3
         D = 2
 
@@ -241,7 +241,7 @@ class TestGaussianMarkovChain(TestCase):
 
 
     def test_message_to_parents_with_inputs(self):
-        """ Check gradient passed to inputs parent node """
+        r""" Check gradient passed to inputs parent node """
 
         def check(Mu, Lambda, A, V, U):
 
@@ -339,7 +339,7 @@ class TestGaussianMarkovChain(TestCase):
 
 
     def test_message_to_child(self):
-        """
+        r"""
         Test the updating of GaussianMarkovChain.
 
         Check that the moments and the lower bound contribution are computed
@@ -694,7 +694,7 @@ class TestGaussianMarkovChain(TestCase):
 
 
     def test_smoothing(self):
-        """
+        r"""
         Test the posterior estimation of GaussianMarkovChain.
 
         Create time-variant dynamics and compare the results of BayesPy VB
@@ -771,7 +771,7 @@ class TestGaussianMarkovChain(TestCase):
 class TestVaryingGaussianMarkovChain(TestCase):
 
     def test_plates_from_parents(self):
-        """
+        r"""
         Test that VaryingGaussianMarkovChain deduces plates correctly
         """
         def check(plates_X,

--- a/bayespy/inference/vmp/nodes/tests/test_mixture.py
+++ b/bayespy/inference/vmp/nodes/tests/test_mixture.py
@@ -32,7 +32,7 @@ from bayespy.utils.misc import TestCase
 class TestMixture(TestCase):
 
     def test_init(self):
-        """
+        r"""
         Test the creation of Mixture node
         """
 
@@ -58,7 +58,7 @@ class TestMixture(TestCase):
         
 
     def test_message_to_child(self):
-        """
+        r"""
         Test the message to child of Mixture node.
         """
 
@@ -107,7 +107,7 @@ class TestMixture(TestCase):
         pass
 
     def test_message_to_parent(self):
-        """
+        r"""
         Test the message to parents of Mixture node.
         """
 
@@ -280,7 +280,7 @@ class TestMixture(TestCase):
 
 
     def test_lowerbound(self):
-        """
+        r"""
         Test log likelihood lower bound for Mixture node
         """
 
@@ -293,7 +293,7 @@ class TestMixture(TestCase):
         pass
 
     def test_mask_to_parent(self):
-        """
+        r"""
         Test the mask handling in Mixture node
         """
 
@@ -322,7 +322,7 @@ class TestMixture(TestCase):
 
 
     def test_nans(self):
-        """
+        r"""
         Test multinomial mixture
         """
 
@@ -356,7 +356,7 @@ class TestMixture(TestCase):
 
 
     def test_random(self):
-        """
+        r"""
         Test random sampling of mixture node
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_multinomial.py
+++ b/bayespy/inference/vmp/nodes/tests/test_multinomial.py
@@ -22,7 +22,7 @@ from bayespy.utils.misc import TestCase
 
 
 class TestMultinomial(TestCase):
-    """
+    r"""
     Unit tests for Multinomial node
     """
 

--- a/bayespy/inference/vmp/nodes/tests/test_multinomial.py
+++ b/bayespy/inference/vmp/nodes/tests/test_multinomial.py
@@ -28,7 +28,7 @@ class TestMultinomial(TestCase):
 
 
     def test_init(self):
-        """
+        r"""
         Test the creation of multinomial nodes.
         """
 
@@ -96,7 +96,7 @@ class TestMultinomial(TestCase):
 
 
     def test_moments(self):
-        """
+        r"""
         Test the moments of multinomial nodes.
         """
 
@@ -159,7 +159,7 @@ class TestMultinomial(TestCase):
 
 
     def test_lower_bound(self):
-        """
+        r"""
         Test lower bound for multinomial node.
         """
 
@@ -172,7 +172,7 @@ class TestMultinomial(TestCase):
 
 
     def test_mixture(self):
-        """
+        r"""
         Test multinomial mixture
         """
 
@@ -187,7 +187,7 @@ class TestMultinomial(TestCase):
         pass
 
     def test_mixture_with_count_array(self):
-        """
+        r"""
         Test multinomial mixture
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_node.py
+++ b/bayespy/inference/vmp/nodes/tests/test_node.py
@@ -27,7 +27,7 @@ from bayespy.utils import misc
 class TestMoments(unittest.TestCase):
 
     def test_converter(self):
-        """
+        r"""
         Tests complex conversions for moment classes
         """
         
@@ -174,7 +174,7 @@ class TestNode(misc.TestCase):
                                 err_msg="Incorrect message.")
 
     def test_message_to_parent(self):
-        """
+        r"""
         Test plate handling in _message_to_parent.
         """
 
@@ -331,7 +331,7 @@ class TestNode(misc.TestCase):
 
 
     def test_compute_message(self):
-        """
+        r"""
         Test the general sum-multiply function for message computations
         """
 
@@ -450,7 +450,7 @@ class TestNode(misc.TestCase):
 class TestSlice(misc.TestCase):
 
     def test_init(self):
-        """
+        r"""
         Test the constructor of the X[..] node operator.
         """
 
@@ -622,7 +622,7 @@ class TestSlice(misc.TestCase):
         pass
 
     def test_message_to_child(self):
-        """
+        r"""
         Test message to child of X[..] node operator.
         """
 
@@ -787,7 +787,7 @@ class TestSlice(misc.TestCase):
         pass
 
     def test_message_to_parent(self):
-        """
+        r"""
         Test message to parent of X[..] node operator.
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_poisson.py
+++ b/bayespy/inference/vmp/nodes/tests/test_poisson.py
@@ -21,7 +21,7 @@ from bayespy.utils.misc import TestCase
 
 
 class TestPoisson(TestCase):
-    """
+    r"""
     Unit tests for Poisson node
     """
 

--- a/bayespy/inference/vmp/nodes/tests/test_poisson.py
+++ b/bayespy/inference/vmp/nodes/tests/test_poisson.py
@@ -27,7 +27,7 @@ class TestPoisson(TestCase):
 
     
     def test_init(self):
-        """
+        r"""
         Test the creation of Poisson nodes.
         """
 
@@ -64,7 +64,7 @@ class TestPoisson(TestCase):
 
     
     def test_moments(self):
-        """
+        r"""
         Test the moments of Poisson nodes.
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_take.py
+++ b/bayespy/inference/vmp/nodes/tests/test_take.py
@@ -23,7 +23,7 @@ class TestTake(TestCase):
 
 
     def test_parent_validity(self):
-        """
+        r"""
         Test that the parent nodes are validated properly
         """
 
@@ -174,7 +174,7 @@ class TestTake(TestCase):
 
 
     def test_moments(self):
-        """
+        r"""
         Test moments computation in Take node
         """
 
@@ -305,7 +305,7 @@ class TestTake(TestCase):
 
 
     def test_message_to_parent(self):
-        """
+        r"""
         Test parent message computation in Take node
         """
 

--- a/bayespy/inference/vmp/nodes/tests/test_wishart.py
+++ b/bayespy/inference/vmp/nodes/tests/test_wishart.py
@@ -41,7 +41,7 @@ def _student_logpdf(y, mu, Cov, nu):
 class TestWishart(TestCase):
 
     def test_lower_bound(self):
-        """
+        r"""
         Test the Wishart VB lower bound
         """
 
@@ -77,7 +77,7 @@ class TestWishart(TestCase):
 
 
     def test_moments(self):
-        """
+        r"""
         Test the moments of Wishart node
         """
 

--- a/bayespy/inference/vmp/nodes/wishart.py
+++ b/bayespy/inference/vmp/nodes/wishart.py
@@ -116,7 +116,7 @@ class WishartMoments(Moments):
 
 
 class WishartDistribution(ExponentialFamilyDistribution):
-    """
+    r"""
     Sub-classes implement distribution specific computations.
 
     Distribution for :math:`k \times k` symmetric positive definite matrix.

--- a/bayespy/inference/vmp/nodes/wishart.py
+++ b/bayespy/inference/vmp/nodes/wishart.py
@@ -30,7 +30,7 @@ class WishartPriorMoments(Moments):
 
 
     def compute_fixed_moments(self, n):
-        """ Compute moments for fixed x. """
+        r""" Compute moments for fixed x. """
         u0 = np.asanyarray(n)
         u1 = special.multigammaln(0.5*u0, self.k)
         return [u0, u1]
@@ -38,7 +38,7 @@ class WishartPriorMoments(Moments):
 
     @classmethod
     def from_values(cls, x, d):
-        """ Compute the dimensions of phi or u. """
+        r""" Compute the dimensions of phi or u. """
         return cls(d)
 
 
@@ -53,7 +53,7 @@ class WishartMoments(Moments):
 
 
     def compute_fixed_moments(self, Lambda, gradient=None):
-        """ Compute moments for fixed x. """
+        r""" Compute moments for fixed x. """
         Lambda = np.asanyarray(Lambda)
         L = linalg.chol(Lambda, ndim=self.ndim)
         ldet = linalg.chol_logdet(L, ndim=self.ndim)
@@ -100,7 +100,7 @@ class WishartMoments(Moments):
 
     @classmethod
     def from_values(cls, x, ndim):
-        """ Compute the dimensions of phi and u. """
+        r""" Compute the dimensions of phi and u. """
         if np.ndim(x) < 2 * ndim:
             raise ValueError("Values for Wishart distribution must be at least "
                              "2-D arrays.")
@@ -253,7 +253,7 @@ class Wishart(ExponentialFamily):
 
 
     def __init__(self, n, V, **kwargs):
-        """
+        r"""
         Create Wishart node.
         """
         super().__init__(n, V, **kwargs)
@@ -261,7 +261,7 @@ class Wishart(ExponentialFamily):
 
     @classmethod
     def _constructor(cls, n, V, **kwargs):
-        """
+        r"""
         Constructs distribution and moments objects.
         """
 

--- a/bayespy/inference/vmp/tests/test_transformations.py
+++ b/bayespy/inference/vmp/tests/test_transformations.py
@@ -31,7 +31,7 @@ from bayespy.utils.misc import TestCase
 class TestRotateGaussianARD(TestCase):
 
     def test_cost_function(self):
-        """
+        r"""
         Test the speed-up rotation of Gaussian ARD arrays.
         """
 
@@ -289,7 +289,7 @@ class TestRotateGaussianARD(TestCase):
         pass
 
     def test_cost_gradient(self):
-        """
+        r"""
         Test gradient of the rotation cost function for Gaussian ARD arrays.
         """
 
@@ -726,7 +726,7 @@ class TestRotateGaussianARD(TestCase):
 class TestRotateGaussianMarkovChain(TestCase):
 
     def test_cost_function(self):
-        """
+        r"""
         Test the cost function of the speed-up rotation for Markov chain
         """
 
@@ -807,7 +807,7 @@ class TestRotateGaussianMarkovChain(TestCase):
         pass
 
     def test_cost_gradient(self):
-        """
+        r"""
         Test the gradient of the speed-up rotation for Markov chain
         """
 
@@ -987,7 +987,7 @@ class TestRotateGaussianMarkovChain(TestCase):
 class TestRotateVaryingMarkovChain(TestCase):
 
     def test_cost_function(self):
-        """
+        r"""
         Test the speed-up rotation of Markov chain with time-varying dynamics
         """
 
@@ -1075,7 +1075,7 @@ class TestRotateVaryingMarkovChain(TestCase):
 
 
     def test_cost_gradient(self):
-        """
+        r"""
         Test the gradient of the rotation for MC with time-varying dynamics
         """
 

--- a/bayespy/inference/vmp/transformations.py
+++ b/bayespy/inference/vmp/transformations.py
@@ -374,7 +374,7 @@ def sum_to_plates(V, plates_to, plates_from=None, ndim=0):
         return r * misc.sum_to_shape(V, shape_to)
 
 class RotateGaussianARD():
-    """
+    r"""
     Rotation parameter expansion for :class:`bayespy.nodes.GaussianARD`
     
     The model:
@@ -1542,7 +1542,7 @@ class RotateVaryingMarkovChain(RotateGaussianMarkovChain):
 
 
 class RotateSwitchingMarkovChain(RotateGaussianMarkovChain):
-    """
+    r"""
     Rotation for :class:`bayespy.nodes.VaryingGaussianMarkovChain`
 
     Assume the following model.

--- a/bayespy/inference/vmp/transformations.py
+++ b/bayespy/inference/vmp/transformations.py
@@ -59,7 +59,7 @@ class RotationOptimizer():
                check_gradient=False,
                verbose=False,
                check_bound=False):
-        """
+        r"""
         Optimize the rotation of two separate model blocks jointly.
 
         If some variable is the dot product of two Gaussians, rotating the two
@@ -103,7 +103,7 @@ class RotationOptimizer():
             return (c, np.ravel(dc))
 
         def get_bound_terms(r, gradient=False):
-            """
+            r"""
             Returns a dictionary of bound terms for the nodes.
             """
             # Gradient not yet implemented..
@@ -234,7 +234,7 @@ class RotateGaussian():
         self.X.rotate(R, inv=inv, logdet=logdet)
 
     def setup(self):
-        """
+        r"""
         This method should be called just before optimization.
         """
         
@@ -390,7 +390,7 @@ class RotateGaussianARD():
     * X and alpha do not contain any observed values
     """
     def __init__(self, X, *alpha, axis=-1, precompute=False, subset=None):
-        """
+        r"""
         Precompute tells whether to compute some moments once in the setup
         function instead of every time in the bound function.  However, they are
         computed a bit differently in the bound function so it can be useful
@@ -473,7 +473,7 @@ class RotateGaussianARD():
             self.node_alpha.update()
 
     def setup(self, plate_axis=None):
-        """
+        r"""
         This method should be called just before optimization.
 
         For efficiency, sum over axes that are not in mu, alpha nor rotation.
@@ -691,7 +691,7 @@ class RotateGaussianARD():
 
 
     def _compute_bound(self, R, logdet=None, inv=None, Q=None, gradient=False, terms=False):
-        """
+        r"""
         Rotate q(X) and q(alpha).
 
         Assume:
@@ -994,7 +994,7 @@ class RotateGaussianARD():
                                   plates_from=plates_X[:-1])
         
         def psi(v):
-            """
+            r"""
             Compute: d/dQ 1/2*trace(diag(v)*<(X-mu)*(X-mu)>)
 
             = Q*<X>'*R'*diag(v)*R*<X> + ones * Q diag( tr(R'*diag(v)*R*Cov) ) 
@@ -1236,7 +1236,7 @@ class RotateGaussianMarkovChain():
         return (A_XpXn, A_XpXp_A, CovA_XpXp)
 
     def setup(self):
-        """
+        r"""
         This method should be called just before optimization.
         """
 
@@ -1296,7 +1296,7 @@ class RotateGaussianMarkovChain():
         #self.v = self.X_node.parents[3].get_moments()[0]
 
     def _compute_bound(self, R, logdet=None, inv=None, gradient=False, terms=False):
-        """
+        r"""
         Rotate q(X) as X->RX: q(X)=N(R*mu, R*Cov*R')
 
         Assume:

--- a/bayespy/inference/vmp/vmp.py
+++ b/bayespy/inference/vmp/vmp.py
@@ -199,7 +199,7 @@ class VB():
         return L
 
     def plot_iteration_by_nodes(self, axes=None, diff=False):
-        """
+        r"""
         Plot the cost function per node during the iteration.
 
         Handy tool for debugging.
@@ -364,7 +364,7 @@ class VB():
             return dictionary[name]
 
     def plot(self, *nodes, **kwargs):
-        """
+        r"""
         Plot the distribution of the given nodes (or all nodes)
         """
 
@@ -400,7 +400,7 @@ class VB():
 
 
     def get_gradients(self, *nodes, euclidian=False):
-        """
+        r"""
         Computes gradients (both Riemannian and normal)
         """
         rg = [self[node].get_riemannian_gradient() for node in nodes]
@@ -413,7 +413,7 @@ class VB():
 
 
     def get_parameters(self, *nodes):
-        """
+        r"""
         Get parameters of the nodes
         """
         return [self[node].get_parameters()
@@ -421,7 +421,7 @@ class VB():
 
 
     def set_parameters(self, x, *nodes):
-        """
+        r"""
         Set parameters of the nodes
         """
         for (node, xi) in zip(nodes, x):
@@ -430,7 +430,7 @@ class VB():
 
 
     def gradient_step(self, *nodes, scale=1.0):
-        """
+        r"""
         Update nodes by taking a gradient ascent step
         """
         p = self.add(self.get_parameters(*nodes),
@@ -441,7 +441,7 @@ class VB():
 
 
     def dot(self, x1, x2):
-        """
+        r"""
         Computes dot products of given vectors (in parameter format)
         """
         v = 0
@@ -454,7 +454,7 @@ class VB():
 
 
     def add(self, x1, x2, scale=1):
-        """
+        r"""
         Add two vectors (in parameter format)
         """
         v = []
@@ -469,7 +469,7 @@ class VB():
 
     def optimize(self, *nodes, maxiter=10, verbose=True, method='fletcher-reeves',
                  riemannian=True, collapsed=None, tol=None):
-        """
+        r"""
         Optimize nodes using Riemannian conjugate gradient
         """
 
@@ -606,7 +606,7 @@ class VB():
 
 
     def pattern_search(self, *nodes, collapsed=None, maxiter=3):
-        """Perform simple pattern search :cite:`Honkela:2003`.
+        r"""Perform simple pattern search :cite:`Honkela:2003`.
 
         Some of the variables can be collapsed.
         """
@@ -663,7 +663,7 @@ class VB():
 
 
     def set_annealing(self, annealing):
-        """
+        r"""
         Set deterministic annealing from range (0, 1].
 
         With 1, no annealing, standard updates.
@@ -680,7 +680,7 @@ class VB():
 
 
     def _append_iterations(self, iters):
-        """
+        r"""
         Append some arrays for more iterations
         """
         self.L = np.append(self.L, misc.nans(iters))
@@ -691,7 +691,7 @@ class VB():
 
 
     def _end_iteration_step(self, method, cputime, tol=None, verbose=True, bound_cpu_time=True):
-        """
+        r"""
         Do some routines after each iteration step
         """
 

--- a/bayespy/plot.py
+++ b/bayespy/plot.py
@@ -85,7 +85,7 @@ pyplot = plt
 
 
 def interactive(function):
-    """A decorator for forcing functions to use the interactive mode.
+    r"""A decorator for forcing functions to use the interactive mode.
 
     Parameters
     ----------
@@ -112,7 +112,7 @@ def interactive(function):
 
 
 def _subplots(plotfunc, *args, fig=None, kwargs=None):
-    """Create a collection of subplots
+    r"""Create a collection of subplots
 
     Each subplot is created with the same plotting function.
 
@@ -168,7 +168,7 @@ def _subplots(plotfunc, *args, fig=None, kwargs=None):
 
 
 def pdf(Z, x, *args, name=None, axes=None, fig=None, **kwargs):
-    """
+    r"""
     Plot probability density function of a scalar variable.
 
     Parameters
@@ -211,7 +211,7 @@ def pdf(Z, x, *args, name=None, axes=None, fig=None, **kwargs):
 
 
 def contour(Z, x, y, n=None, axes=None, fig=None, **kwargs):
-    """
+    r"""
     Plot 2-D probability density function of a 2-D variable.
 
     Parameters
@@ -255,7 +255,7 @@ def contour(Z, x, y, n=None, axes=None, fig=None, **kwargs):
 
 
 def plot_gaussian_mc(X, scale=2, **kwargs):
-    """
+    r"""
     Plot Gaussian Markov chain as a 1-D function
 
     Parameters
@@ -267,7 +267,7 @@ def plot_gaussian_mc(X, scale=2, **kwargs):
 
 
 def plot_bernoulli(X, axis=-1, scale=2, **kwargs):
-    """
+    r"""
     Plot Bernoulli node as a 1-D function
     """
     X = X._ensure_moments(X, BernoulliMoments)
@@ -277,7 +277,7 @@ def plot_bernoulli(X, axis=-1, scale=2, **kwargs):
 
 
 def plot_gaussian(X, axis=-1, scale=2, **kwargs):
-    """
+    r"""
     Plot Gaussian node as a 1-D function
 
     Parameters
@@ -298,7 +298,7 @@ def plot_gaussian(X, axis=-1, scale=2, **kwargs):
 
 
 def plot(Y, axis=-1, scale=2, center=False, **kwargs):
-    """
+    r"""
     Plot a variable or an array as 1-D function with errorbars
     """
     if misc.is_numeric(Y):
@@ -419,7 +419,7 @@ def _timeseries_mean_and_error(y, std, *args, axis=-1, center=True, fig=None, ax
 
 
 def _blob(axes, x, y, area, colour):
-    """
+    r"""
     Draws a square-shaped blob with the given area (< 1) at
     the given coordinates.
     """
@@ -440,7 +440,7 @@ def _rectangle(axes, x, y, width, height, **kwargs):
 
 
 def gaussian_mixture_2d(X, alpha=None, scale=2, fill=False, axes=None, **kwargs):
-    """
+    r"""
     Plot Gaussian mixture as ellipses in 2-D
 
     Parameters
@@ -517,7 +517,7 @@ def gaussian_mixture_2d(X, alpha=None, scale=2, fill=False, axes=None, **kwargs)
 
 
 def _hinton(W, error=None, vmax=None, square=False, axes=None):
-    """
+    r"""
     Draws a Hinton diagram for visualizing a weight matrix.
 
     Temporarily disables matplotlib interactive mode if it is on,
@@ -602,7 +602,7 @@ def new_matrix(A, vmax=None):
             pass
 
 def gaussian_hinton(X, rows=None, cols=None, scale=1, fig=None):
-    """
+    r"""
     Plot the Hinton diagram of a Gaussian node
     """
 
@@ -686,7 +686,7 @@ def gaussian_hinton(X, rows=None, cols=None, scale=1, fig=None):
 
 
 def _hinton_figure(x, rows=None, cols=None, fig=None, square=True):
-    """
+    r"""
     Plot the Hinton diagram of a Gaussian node
     """
 
@@ -786,7 +786,7 @@ def timeseries_categorical_mc(Z, fig=None):
 
 
 def gamma_hinton(alpha, square=True, **kwargs):
-    """
+    r"""
     Plot a beta distributed random variable as a Hinton diagram
     """
 
@@ -804,7 +804,7 @@ def gamma_hinton(alpha, square=True, **kwargs):
 
 
 def beta_hinton(P, square=True):
-    """
+    r"""
     Plot a beta distributed random variable as a Hinton diagram
     """
 
@@ -822,7 +822,7 @@ def beta_hinton(P, square=True):
 
 
 def dirichlet_hinton(P, square=True):
-    """
+    r"""
     Plot a beta distributed random variable as a Hinton diagram
     """
 
@@ -840,7 +840,7 @@ def dirichlet_hinton(P, square=True):
 
 
 def bernoulli_hinton(Z, square=True):
-    """
+    r"""
     Plot a Bernoulli distributed random variable as a Hinton diagram
     """
 
@@ -858,7 +858,7 @@ def bernoulli_hinton(Z, square=True):
 
 
 def categorical_hinton(Z, square=True):
-    """
+    r"""
     Plot a Bernoulli distributed random variable as a Hinton diagram
     """
 
@@ -1227,7 +1227,7 @@ def matrixplot(A, colorbar=False, axes=None):
 
 
 def contourplot(x1, x2, y, colorbar=False, filled=True, axes=None):
-    """ Plots 2D contour plot. x1 and x2 are 1D vectors, y contains
+    r""" Plots 2D contour plot. x1 and x2 are 1D vectors, y contains
     the function values. y.size must be x1.size*x2.size. """
 
     if axes is None:
@@ -1283,7 +1283,7 @@ def errorplot(y=None, error=None, x=None, lower=None, upper=None,
 
 
 def plotmatrix(X):
-    """
+    r"""
     Creates a matrix of marginal plots.
 
     On diagonal, are marginal plots of each variable. Off-diagonal plot (i,j)
@@ -1293,7 +1293,7 @@ def plotmatrix(X):
 
 
 def _pdf_t(mu, s2, nu, axes=None, scale=4, color='k'):
-    """
+    r"""
     """
     if axes is None:
         axes = plt.gca()
@@ -1307,7 +1307,7 @@ def _pdf_t(mu, s2, nu, axes=None, scale=4, color='k'):
 
 
 def _pdf_gamma(a, b, axes=None, scale=4, color='k'):
-    """
+    r"""
     """
     if axes is None:
         axes = plt.gca()
@@ -1330,7 +1330,7 @@ def _pdf_gamma(a, b, axes=None, scale=4, color='k'):
 
 
 def _contour_t(mu, Cov, nu, axes=None, scale=4, transpose=False, colors='k'):
-    """
+    r"""
     """
     if axes is None:
         axes = plt.gca()
@@ -1362,13 +1362,13 @@ def _contour_t(mu, Cov, nu, axes=None, scale=4, transpose=False, colors='k'):
 
 
 def _contour_gaussian_gamma(mu, s2, a, b, axes=None, transpose=False):
-    """
+    r"""
     """
     pass
 
 
 def ellipse_from_cov(xy, cov, scale=2, **kwargs):
-    """
+    r"""
     Create an ellipse from a covariance matrix.
 
     Parameters
@@ -1393,7 +1393,7 @@ def ellipse_from_cov(xy, cov, scale=2, **kwargs):
 
 
 def ellipse_from_precision(xy, precision, scale=2, **kwargs):
-    """
+    r"""
     Create an ellipse from a covariance matrix.
 
     Parameters

--- a/bayespy/plot.py
+++ b/bayespy/plot.py
@@ -1005,7 +1005,7 @@ class Plotter():
 
 
     def __call__(self, X, fig=None, **kwargs):
-        """
+        r"""
         Plot the node using the specified plotting function
 
         Parameters

--- a/bayespy/testing.py
+++ b/bayespy/testing.py
@@ -15,7 +15,7 @@ class WarnAsError(Plugin):
 
 
     def options(self, parser, env):
-        """
+        r"""
         Add options to command line.
         """
         super().options(parser, env)
@@ -26,7 +26,7 @@ class WarnAsError(Plugin):
 
 
     def configure(self, options, conf):
-        """
+        r"""
         Configure plugin.
         """
         super().configure(options, conf)
@@ -35,7 +35,7 @@ class WarnAsError(Plugin):
 
 
     def prepareTestRunner(self, runner):
-        """
+        r"""
         Treat warnings as errors.
         """
         if self.enabled:

--- a/bayespy/utils/linalg.py
+++ b/bayespy/utils/linalg.py
@@ -231,7 +231,7 @@ def logdet_chol(U):
 
 
 def logdet_tri(R):
-    """
+    r"""
     Logarithm of the absolute value of the determinant of a triangular matrix.
     """
     return np.sum(np.log(np.abs(np.einsum('...ii->...i', R))))
@@ -297,7 +297,7 @@ def solve_triangular(U, B, ndim=1, **kwargs):
 
 
 def inner(*args, ndim=1):
-    """
+    r"""
     Compute inner product.
 
     The number of arrays is arbitrary.  The number of dimensions is arbitrary.
@@ -307,7 +307,7 @@ def inner(*args, ndim=1):
 
 
 def outer(A, B, ndim=1):
-    """
+    r"""
     Computes outer product over the last axes of A and B.
 
     The other axes are broadcasted. Thus, if A has shape (..., N) and B has
@@ -335,7 +335,7 @@ def outer(A, B, ndim=1):
 
 
 def _dot(A, B):
-    """
+    r"""
     Dot product which handles broadcasting properly.
 
     Future NumPy will have a better built-in implementation for this.
@@ -356,7 +356,7 @@ def _dot(A, B):
     return Y
 
 def dot(*arrays):
-    """
+    r"""
     Compute matrix-matrix product.
 
     You can give multiple arrays, the dot product is computed from left to
@@ -380,14 +380,14 @@ def dot(*arrays):
         return Y
 
 def tracedot(A, B):
-    """
+    r"""
     Computes trace(A*B).
     """
     return np.einsum('...ij,...ji->...', A, B)
 
 
 def inv(A, ndim=1):
-    """
+    r"""
     General array inversion.
 
     Supports broadcasting and inversion of multidimensional arrays.  For
@@ -405,7 +405,7 @@ def inv(A, ndim=1):
 
 
 def mvdot(A, b, ndim=1):
-    """
+    r"""
     Compute matrix-vector product.
 
     Applies broadcasting.
@@ -428,7 +428,7 @@ def mvdot(A, b, ndim=1):
     ## #return np.einsum('...ik,...k->...i', A, b)
 
 def mmdot(A, B, ndim=1):
-    """
+    r"""
     Compute matrix-matrix product.
 
     Applies broadcasting.
@@ -442,7 +442,7 @@ def mmdot(A, B, ndim=1):
     #return np.einsum('...ik,...kj->...ij', A, B)
 
 def transpose(X, ndim=1):
-    """
+    r"""
     Transpose the matrix.
     """
     for n in range(ndim):
@@ -466,7 +466,7 @@ def m_dot(A,b):
     #return np.sum(A*b[...,np.newaxis,:], axis=(-1,))
 
 def block_banded_solve(A, B, y):
-    """
+    r"""
     Invert symmetric, banded, positive-definite matrix.
 
     A contains the diagonal blocks.

--- a/bayespy/utils/misc.py
+++ b/bayespy/utils/misc.py
@@ -60,7 +60,7 @@ def reshape_axes(X, *shapes):
 
 
 def find_set_index(index, set_lengths):
-    """
+    r"""
     Given set sizes and an index, returns the index of the set
 
     The given index is for the concatenated list of the sets.
@@ -77,7 +77,7 @@ def find_set_index(index, set_lengths):
 
 
 def parse_command_line_arguments(mandatory_args, *optional_args_list, argv=None):
-    """
+    r"""
     Parse command line arguments of style "--parameter=value".
 
     Parameter specification is tuple: (name, converter, description).
@@ -269,7 +269,7 @@ def parse_command_line_arguments(mandatory_args, *optional_args_list, argv=None)
 
 
 def composite_function(function_list):
-    """
+    r"""
     Construct a function composition from a list of functions.
 
     Given a list of functions [f,g,h], constructs a function :math:`h \circ g
@@ -284,7 +284,7 @@ def composite_function(function_list):
 
 
 def ceildiv(a, b):
-    """
+    r"""
     Compute a divided by b and rounded up.
     """
     return -(-a // b)
@@ -302,13 +302,13 @@ def atleast_nd(X, d):
     return X
 
 def T(X):
-    """
+    r"""
     Transpose the matrix.
     """
     return np.swapaxes(X, -1, -2)
 
 class TestCase(unittest.TestCase):
-    """
+    r"""
     Simple base class for unit testing.
 
     Adds NumPy's features to Python's unittest.
@@ -437,13 +437,13 @@ class TestCase(unittest.TestCase):
 
 
 def symm(X):
-    """
+    r"""
     Make X symmetric.
     """
     return 0.5 * (X + np.swapaxes(X, -1, -2))
 
 def unique(l):
-    """
+    r"""
     Remove duplicate items from a list while preserving order.
     """
     seen = set()
@@ -454,7 +454,7 @@ def tempfile(prefix='', suffix=''):
     return tmp.NamedTemporaryFile(prefix=prefix, suffix=suffix).name
 
 def write_to_hdf5(group, data, name):
-    """
+    r"""
     Writes the given array into the HDF5 file.
     """
     try:
@@ -488,7 +488,7 @@ def array_to_scalar(x):
 
 
 def put(x, indices, y, axis=-1, ufunc=np.add):
-    """A kind of inverse mapping of `np.take`
+    r"""A kind of inverse mapping of `np.take`
 
     In a simple, the operation can be thought as:
 
@@ -547,7 +547,7 @@ def put(x, indices, y, axis=-1, ufunc=np.add):
 
 
 def put_simple(y, indices, axis=-1, length=None):
-    """An inverse operation of `np.take` with accumulation and broadcasting.
+    r"""An inverse operation of `np.take` with accumulation and broadcasting.
 
     Compared to `put`, the difference is that the result array is initialized
     with an array of zeros whose shape is determined automatically and `np.add`
@@ -586,7 +586,7 @@ def put_simple(y, indices, axis=-1, length=None):
 
 
 def grid(x1, x2):
-    """ Returns meshgrid as a (M*N,2)-shape array. """
+    r""" Returns meshgrid as a (M*N,2)-shape array. """
     (X1, X2) = np.meshgrid(x1, x2)
     return np.hstack((X1.reshape((-1,1)),X2.reshape((-1,1))))
 
@@ -668,7 +668,7 @@ def gaussian_logpdf(y_invcov_y,
 
 
 def zipper_merge(*lists):
-    """
+    r"""
     Combines lists by alternating elements from them.
 
     Combining lists [1,2,3], ['a','b','c'] and [42,666,99] results in
@@ -704,7 +704,7 @@ def is_string(s):
     return isinstance(s, str)
 
 def multiply_shapes(*shapes):
-    """
+    r"""
     Compute element-wise product of lists/tuples.
 
     Shorter lists are concatenated with leading 1s in order to get lists with
@@ -721,7 +721,7 @@ def multiply_shapes(*shapes):
     return tuple(shape)
 
 def make_equal_length(*shapes):
-    """
+    r"""
     Make tuples equal length.
 
     Add leading 1s to shorter tuples.
@@ -737,7 +737,7 @@ def make_equal_length(*shapes):
 
 
 def make_equal_ndim(*arrays):
-    """
+    r"""
     Add trailing unit axes so that arrays have equal ndim
     """
     shapes = [np.shape(array) for array in arrays]
@@ -748,7 +748,7 @@ def make_equal_ndim(*arrays):
 
 
 def sum_to_dim(A, dim):
-    """
+    r"""
     Sum leading axes of A such that A has dim dimensions.
     """
     dimdiff = np.ndim(A) - dim
@@ -759,7 +759,7 @@ def sum_to_dim(A, dim):
 
 
 def broadcasting_multiplier(plates, *args):
-    """
+    r"""
     Compute the plate multiplier for given shapes.
 
     The first shape is compared to all other shapes (using NumPy
@@ -803,7 +803,7 @@ def broadcasting_multiplier(plates, *args):
 
 
 def sum_multiply_to_plates(*arrays, to_plates=(), from_plates=None, ndim=0):
-    """
+    r"""
     Compute the product of the arguments and sum to the target shape.
     """
     arrays = list(arrays)
@@ -945,7 +945,7 @@ def sum_product(*args, axes_to_keep=None, axes_to_sum=None, keepdims=False):
                             keepdims=keepdims)
 
 def moveaxis(A, axis_from, axis_to):
-    """
+    r"""
     Move the axis `axis_from` to position `axis_to`.
     """
     if ((axis_from < 0 and abs(axis_from) > np.ndim(A)) or
@@ -967,7 +967,7 @@ def moveaxis(A, axis_from, axis_to):
 
 
 def safe_indices(inds, shape):
-    """
+    r"""
     Makes sure that indices are valid for given shape.
 
     The shorter shape determines the length.
@@ -993,7 +993,7 @@ def safe_indices(inds, shape):
 
 
 def broadcasted_shape(*shapes):
-    """
+    r"""
     Computes the resulting broadcasted shape for a given set of shapes.
 
     Uses the broadcasting rules of NumPy.  Raises an exception if the shapes do
@@ -1015,7 +1015,7 @@ def broadcasted_shape(*shapes):
     return S
 
 def broadcasted_shape_from_arrays(*arrays):
-    """
+    r"""
     Computes the resulting broadcasted shape for a given set of arrays.
 
     Raises an exception if the shapes do not broadcast.
@@ -1026,7 +1026,7 @@ def broadcasted_shape_from_arrays(*arrays):
 
 
 def is_shape_subset(sub_shape, full_shape):
-    """
+    r"""
     """
     if len(sub_shape) > len(full_shape):
         return False
@@ -1058,7 +1058,7 @@ def nested_iterator(max_inds):
     return itertools.product(*s)
 
 def first(L):
-    """
+    r"""
     """
     for (n,l) in enumerate(L):
         if l:
@@ -1066,7 +1066,7 @@ def first(L):
     return None
 
 def squeeze(X):
-    """
+    r"""
     Remove leading axes that have unit length.
 
     For instance, a shape (1,1,4,1,3) will be reshaped to (4,1,3).
@@ -1100,7 +1100,7 @@ def axes_to_collapse(shape_x, shape_to):
     return tuple(s)
 
 def sum_to_shape(X, s):
-    """
+    r"""
     Sum axes of the array such that the resulting shape is as given.
 
     Thus, the shape of the result will be s or an error is raised.
@@ -1144,7 +1144,7 @@ def repeat_to_shape(A, s):
     return A
 
 def multidigamma(a, d):
-    """
+    r"""
     Returns the derivative of the log of multivariate gamma.
     """
     return np.sum(special.digamma(a[...,None] - 0.5*np.arange(d)),
@@ -1158,7 +1158,7 @@ def diagonal(A):
 
 
 def make_diag(X, ndim=1, ndim_from=0):
-    """
+    r"""
     Create a diagonal array given the diagonal elements.
 
     The diagonal array can be multi-dimensional. By default, the last axis is
@@ -1205,7 +1205,7 @@ def make_diag(X, ndim=1, ndim_from=0):
 
 
 def get_diag(X, ndim=1, ndim_to=0):
-    """
+    r"""
     Get the diagonal of an array.
 
     If ndim>1, take the diagonal of the last 2*ndim axes.
@@ -1251,7 +1251,7 @@ def get_diag(X, ndim=1, ndim_to=0):
 
 
 def diag(X, ndim=1):
-    """
+    r"""
     Create a diagonal array given the diagonal elements.
 
     The diagonal array can be multi-dimensional. By default, the last axis is
@@ -1284,7 +1284,7 @@ def m_dot(A,b):
 
 
 def block_banded(D, B):
-    """
+    r"""
     Construct a symmetric block-banded matrix.
 
     `D` contains square diagonal blocks.
@@ -1364,7 +1364,7 @@ def dist_haversine(c1, c2, radius=6372795):
     return radius * C
 
 def logsumexp(X, axis=None, keepdims=False):
-    """
+    r"""
     Compute log(sum(exp(X)) in a numerically stable way
     """
 
@@ -1386,7 +1386,7 @@ def logsumexp(X, axis=None, keepdims=False):
 
 
 def normalized_exp(phi):
-    """Compute exp(phi) so that exp(phi) sums to one.
+    r"""Compute exp(phi) so that exp(phi) sums to one.
 
     This is useful for computing probabilities from log evidence.
     """
@@ -1453,7 +1453,7 @@ def invgamma(x):
 
 
 def mean(X, axis=None, keepdims=False):
-    """
+    r"""
     Compute the mean, ignoring NaNs.
     """
     if np.ndim(X) == 0:
@@ -1474,7 +1474,7 @@ def gradient(f, x, epsilon=1e-6):
 
 
 def broadcast(*arrays, ignore_axis=None):
-    """
+    r"""
     Explicitly broadcast arrays to same shapes.
 
     It is possible ignore some axes so that the arrays are not broadcasted
@@ -1515,7 +1515,7 @@ def broadcast(*arrays, ignore_axis=None):
 
 
 def block_diag(*arrays):
-    """
+    r"""
     Form a block diagonal array from the given arrays.
 
     Compared to SciPy's block_diag, this utilizes broadcasting and accepts more
@@ -1545,7 +1545,7 @@ def block_diag(*arrays):
 
 
 def concatenate(*arrays, axis=-1):
-    """
+    r"""
     Concatenate arrays along a given axis.
 
     Compared to NumPy's concatenate, this utilizes broadcasting.

--- a/bayespy/utils/optimize.py
+++ b/bayespy/utils/optimize.py
@@ -13,7 +13,7 @@ _epsilon = np.sqrt(np.finfo(float).eps)
 
 
 def minimize(f, x0, maxiter=None, verbose=False):
-    """
+    r"""
     Simple wrapper for SciPy's optimize.
 
     The given function must return a tuple: (value, gradient).
@@ -25,7 +25,7 @@ def minimize(f, x0, maxiter=None, verbose=False):
     return opt.x
 
 def check_gradient(f, x0, verbose=True, epsilon=_epsilon, return_abserr=False):
-    """
+    r"""
     Simple wrapper for SciPy's gradient checker.
 
     The given function must return a tuple: (value, gradient).
@@ -50,4 +50,3 @@ def check_gradient(f, x0, verbose=True, epsilon=_epsilon, return_abserr=False):
                abserr))
 
     return (abserr, err)
-

--- a/bayespy/utils/tests/test_linalg.py
+++ b/bayespy/utils/tests/test_linalg.py
@@ -17,7 +17,7 @@ from .. import linalg
 class TestDot(misc.TestCase):
 
     def test_dot(self):
-        """
+        r"""
         Test dot product multiple multi-dimensional arrays.
         """
 
@@ -112,7 +112,7 @@ class TestDot(misc.TestCase):
 class TestBandedSolve(misc.TestCase):
 
     def test_block_banded_solve(self):
-        """
+        r"""
         Test the Gaussian elimination algorithm for block-banded matrices.
         """
 

--- a/bayespy/utils/tests/test_misc.py
+++ b/bayespy/utils/tests/test_misc.py
@@ -23,7 +23,7 @@ from .. import misc
 class TestCeilDiv(misc.TestCase):
 
     def test_ceildiv(self):
-        """
+        r"""
         Test the ceil division
         """
 
@@ -67,7 +67,7 @@ class TestCeilDiv(misc.TestCase):
 class TestAddAxes(misc.TestCase):
 
     def test_add_axes(self):
-        """
+        r"""
         Test the add_axes method.
         """
         f = lambda X, **kwargs: np.shape(misc.add_axes(X, **kwargs))
@@ -201,7 +201,7 @@ class TestSumMultiply(unittest.TestCase):
         
 
     def test_sum_multiply(self):
-        """
+        r"""
         Test misc.sum_multiply.
         """
         # Check empty list returns error
@@ -342,7 +342,7 @@ class TestSumMultiply(unittest.TestCase):
 class TestLogSumExp(misc.TestCase):
 
     def test_logsumexp(self):
-        """
+        r"""
         Test the ceil division
         """
 
@@ -389,7 +389,7 @@ class TestLogSumExp(misc.TestCase):
 class TestMean(misc.TestCase):
 
     def test_mean(self):
-        """
+        r"""
         Test the ceil division
         """
 

--- a/bayespy/utils/tests/test_random.py
+++ b/bayespy/utils/tests/test_random.py
@@ -62,7 +62,7 @@ class TestCeilDiv(misc.TestCase):
 
 
 class TestDirichlet(misc.TestCase):
-    """
+    r"""
     Unit tests for the Dirichlet random sampling
     """
 

--- a/bayespy/utils/tests/test_random.py
+++ b/bayespy/utils/tests/test_random.py
@@ -67,7 +67,7 @@ class TestDirichlet(misc.TestCase):
     """
 
     def test(self):
-        """
+        r"""
         Test random sampling from the Dirichlet distribution.
         """
 
@@ -100,7 +100,7 @@ class TestDirichlet(misc.TestCase):
 class TestAlphaBetaRecursion(misc.TestCase):
     
     def test(self):
-        """
+        r"""
         Test the results of alpha-beta recursion for Markov chains
         """
 


### PR DESCRIPTION
Docstrings with math with the escape character `\` don't work in python >=3.12 (fails at import). When running the code in debugger with PyCharm 2024 version I get a `SyntaxError` from docstrings.


```
    from . import misc
E     File "/home/anttimc/conda_new/envs/lh-py311-Nov23/lib/python3.11/site-packages/bayespy/utils/misc.py", line 272
E       """
E       ^^^
E   SyntaxError: invalid escape sequence '\c'
```

This change replaces regular-string docstrings with find-and-replace to raw strings.