### PR TITLE
Fix array-to-scalar conversion for NumPy 2.4 compatibility

### DIFF
--- a/bayespy/inference/vmp/nodes/node.py
+++ b/bayespy/inference/vmp/nodes/node.py
@@ -1076,7 +1076,10 @@ class Slice(Deterministic):
         elif np.ndim(m_child) == 0:
             m_parent[parent_slices] = m_child
         else:
-            m_parent[parent_slices] = m_child[child_slices]
+            val = m_child[child_slices]
+            if val.ndim > 0 and val.size == 1:
+                val = val.item()
+            m_parent[parent_slices] = val
 
         return m_parent
 

--- a/bayespy/inference/vmp/nodes/tests/test_node.py
+++ b/bayespy/inference/vmp/nodes/tests/test_node.py
@@ -841,7 +841,7 @@ class TestSlice(misc.TestCase):
         X = V[2,2]
         m = [ np.random.randn(1) ]
         msg = [ np.zeros((3,3)) ]
-        msg[0][2,2] = m[0]
+        msg[0][2,2] = m[0].item()
         Y = ChildNode(X, m, True, dims=((),))
         X._update_mask()
         self.assertMessage(X._message_to_parent(0),


### PR DESCRIPTION
NumPy 1.25 deprecated implicit conversion of ndim > 0 arrays to scalars, and NumPy 2.4 now raises TypeError.

This PR fixes the two affected locations:
- `node.py`: Use `.item()` to extract a scalar when assigning a single-element array to a scalar slot in `__reverse_indexing`
- `test_node.py`: Use `.item()` when constructing the expected message in `test_message_to_parent`


See [NumPy 2.4 expired-deprecations](https://numpy.org/doc/stable/release/2.4.0-notes.html#raise-typeerror-on-attempt-to-convert-array-with-ndim-0-to-scalar)