### PR TITLE
Fix VB class resource warning

### DIFF
--- a/bayespy/inference/vmp/vmp.py
+++ b/bayespy/inference/vmp/vmp.py
@@ -90,9 +90,9 @@ class VB():
         if not autosave_filename:
             date = datetime.datetime.today().strftime('%Y%m%d%H%M%S')
             prefix = 'vb_autosave_%s_' % date
-            tmpfile = tempfile.NamedTemporaryFile(prefix=prefix,
-                                                  suffix='.hdf5')
-            self.autosave_filename = tmpfile.name
+            self._autosave_tmpfile = tempfile.NamedTemporaryFile(prefix=prefix,
+                                                                  suffix='.hdf5')
+            self.autosave_filename = self._autosave_tmpfile.name
             self.filename = None
         else:
             self.autosave_filename = autosave_filename


### PR DESCRIPTION
Python 3.14 raises the following warning for a tempfile used by the VB class
`ResourceWarning: Implicitly cleaning up <_TemporaryFileWrapper file=<_io.BufferedRandom name='/tmp/vb_autosave_20260602133600_0yxcsy6t.hdf5'>>`

To fix the warning, the tempfile created at `__init__` should be assigned to the object so that the resource is cleaned up when the reference count to the VB object goes to zero. This is what the commit does.